### PR TITLE
[Sync] Update project files from source repository (ca0ff0d)

### DIFF
--- a/.github/actions/setup-benchstat/action.yml
+++ b/.github/actions/setup-benchstat/action.yml
@@ -106,12 +106,18 @@ runs:
         MAJOR=$(echo "$GO_VERSION" | sed -E 's/^([0-9]+)\..*/\1/')
         MINOR=$(echo "$GO_VERSION" | sed -E 's/^[0-9]+\.([0-9]+).*/\1/')
 
-        # Parse the latest-build minimum Go threshold (default to 1.26 if malformed).
-        MIN_MAJOR=$(echo "$BENCHSTAT_LATEST_MIN_GO" | sed -E 's/^([0-9]+)\..*/\1/')
-        MIN_MINOR=$(echo "$BENCHSTAT_LATEST_MIN_GO" | sed -E 's/^[0-9]+\.([0-9]+).*/\1/')
-        if ! [[ "$MIN_MAJOR" =~ ^[0-9]+$ ]] || ! [[ "$MIN_MINOR" =~ ^[0-9]+$ ]]; then
-          MIN_MAJOR=1
-          MIN_MINOR=26
+        # Parse and validate the latest-build minimum Go threshold. Empty input already
+        # defaults to 1.26 above, so a non-empty value that fails to parse is a real config
+        # error (typo). Fail fast with a clear message rather than silently falling back to a
+        # possibly-stale hard-coded 1.26, which could select an incompatible build once the
+        # latest benchstat requires Go 1.27+. Anchored match also rejects inputs the old
+        # sed-based check missed (e.g. "127", "1.2z"). Mirrors the GO_VERSION check below.
+        if [[ "$BENCHSTAT_LATEST_MIN_GO" =~ ^([0-9]+)\.([0-9]+)(\.(x|[0-9]+))?$ ]]; then
+          MIN_MAJOR="${BASH_REMATCH[1]}"
+          MIN_MINOR="${BASH_REMATCH[2]}"
+        else
+          echo "❌ Could not parse benchstat latest minimum Go version '$BENCHSTAT_LATEST_MIN_GO'. Please provide a valid Go version (e.g., '1.26', '1.27.x')." >&2
+          exit 1
         fi
 
         if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || ! [[ "$MAJOR" =~ ^[0-9]+$ ]] || ! [[ "$MINOR" =~ ^[0-9]+$ ]]; then

--- a/.github/workflows/fortress-test-matrix.yml
+++ b/.github/workflows/fortress-test-matrix.yml
@@ -134,6 +134,25 @@ jobs:
 
     steps:
       # --------------------------------------------------------------------
+      # Guard: this workflow is bash-only and does not support Windows runners.
+      # matrix.os comes from inputs.test-matrix (caller-provided), so fail fast
+      # with a clear message instead of letting later bash-only steps error out
+      # under PowerShell (the default shell on Windows runners) in confusing,
+      # partial ways. `shell: bash` is required so this guard runs under Git Bash
+      # even on a Windows runner and can emit its own message before exiting.
+      # --------------------------------------------------------------------
+      - name: 🛑 Guard against unsupported Windows runners
+        shell: bash
+        run: |
+          MATRIX_OS="${{ matrix.os }}"
+          if [[ "$MATRIX_OS" == windows* ]]; then
+            echo "::error title=Unsupported runner (${{ matrix.name }})::This test matrix workflow is bash-only and does not support Windows runners (got '$MATRIX_OS'). Use ubuntu-* runners, or macOS configured as PRIMARY_RUNNER/SECONDARY_RUNNER."
+            echo "❌ Windows runner '$MATRIX_OS' is not supported — every step here is bash-only."
+            exit 1
+          fi
+          echo "✅ Runner '$MATRIX_OS' is supported (bash available)"
+
+      # --------------------------------------------------------------------
       # Checkout code (required for local actions)
       # --------------------------------------------------------------------
       - name: 📥 Checkout code


### PR DESCRIPTION
## What Changed

* Replaced the fallback-based parsing logic for `BENCHSTAT_LATEST_MIN_GO` in `.github/actions/setup-benchstat/action.yml` with a strict regex validation that fails fast on invalid input
* Changed from `sed`-based parsing with silent fallback to 1.26 defaults to a `BASH_REMATCH`-based approach that exits with a clear error message when the version cannot be parsed
* Added a new guard step at the beginning of `.github/workflows/fortress-test-matrix.yml` that explicitly blocks Windows runners with a clear error message
* The new guard step uses `shell: bash` to detect `windows*` in `matrix.os` and exits immediately before other bash-only steps can fail in confusing ways

## Why It Was Necessary

* The old `sed`-based parsing would silently fall back to hard-coded 1.26 defaults on malformed input, which could select incompatible builds once benchstat requires Go 1.27+ without surfacing the configuration error
* The old regex allowed invalid inputs like "127" or "1.2z" to pass through, and typos in version strings would go undetected
* The fortress test matrix workflow is bash-only but could be invoked with Windows runners from caller-provided inputs, causing confusing partial failures under PowerShell instead of clear upfront error messages

## Testing Performed

* Validated that the new regex pattern correctly matches valid Go versions (e.g., "1.26", "1.27.x", "1.26.3") and rejects invalid ones
* Confirmed that malformed `BENCHSTAT_LATEST_MIN_GO` values now trigger immediate failure with the clear error message instead of silent fallback
* Verified that the Windows runner guard runs under Git Bash on Windows runners and emits the expected error before any other steps execute

## Impact / Risk

* **Low Risk**: Changes improve error detection by failing fast on invalid configuration rather than silently using stale defaults
* **Breaking Change**: Workflows that previously relied on silent fallback to 1.26 for malformed `BENCHSTAT_LATEST_MIN_GO` values will now fail explicitly—this is intentional to surface configuration errors
* **Developer Experience**: Both changes provide clearer, more actionable error messages when configuration is invalid or incompatible runners are used

<!-- go-broadcast-metadata
group:
  id: bitcoin-schema
  name: bitcoin-schema
diff_info:
  staged_repo_available: true
  changed_files_count: 2
  files_with_original_content: 2
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: ca0ff0d7d46667601d02de893c02366e80551447
  target_repo: BitcoinSchema/go-bitcoin
  sync_commit: 79cc56e37658113322b8ae2705031bba2129cb00
  sync_time: 2026-08-21T12:37:26-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 347
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1056
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 332
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 456
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 298
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 731
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 922
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 404
performance:
  total_files: 102
-->
