### PR TITLE
[Sync] Update project files from source repository (d0f1a8f)

### DIFF
--- a/.github/actions/setup-benchstat/action.yml
+++ b/.github/actions/setup-benchstat/action.yml
@@ -105,8 +105,16 @@ runs:
         #   "1.22"    -> MAJOR=1, MINOR=22
         #   "1.23.5"  -> MAJOR=1, MINOR=23
         #   "2.0.0"   -> MAJOR=2, MINOR=0
-        MAJOR=$(echo "$GO_VERSION" | sed -E 's/^([0-9]+)\..*/\1/')
-        MINOR=$(echo "$GO_VERSION" | sed -E 's/^[0-9]+\.([0-9]+).*/\1/')
+        # Anchored match so malformed inputs (e.g. "1.25junk", "127", "1.2z") are rejected
+        # by the validation below instead of being silently coerced — the old sed-based
+        # extraction accepted "1.25junk" as 1.25. Mirrors the BENCHSTAT_LATEST_MIN_GO check.
+        if [[ "$GO_VERSION" =~ ^([0-9]+)\.([0-9]+)(\.(x|[0-9]+))?$ ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+        else
+          MAJOR=""
+          MINOR=""
+        fi
 
         # Parse and validate the latest-build minimum Go threshold. Empty input already
         # defaults to 1.26 above, so a non-empty value that fails to parse is a real config

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.26.3
+MAGE_X_VERSION=v1.26.4
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -81,7 +81,7 @@ MAGE_X_NANCY_VERSION=v2.1.0
 # OSV-Scanner version for MAGE-X parity (authoritative pin is OSV_SCANNER_VERSION in
 # 10-security.env, which the CI workflow uses to `go install` the scanner).
 MAGE_X_OSV_SCANNER_VERSION=v2.5.1
-MAGE_X_STATICCHECK_VERSION=2026.2
+MAGE_X_STATICCHECK_VERSION=2026.2.1
 MAGE_X_SWAG_VERSION=v1.16.6
 MAGE_X_YAMLFMT_VERSION=v0.21.0
 # benchstat is versioned by two pins. golang.org/x/perf ships only pseudo-versions

--- a/.github/workflows/fortress-test-matrix.yml
+++ b/.github/workflows/fortress-test-matrix.yml
@@ -5,9 +5,11 @@
 #  in a matrix strategy with native CI mode for failure detection and reporting.
 #
 #  This workflow handles:
-#    - Linux test execution (ubuntu runners; macOS only if a runner is configured
-#      as PRIMARY_RUNNER/SECONDARY_RUNNER). Windows is not supported — every step
-#      here is bash-only, so do not add windows runners without adding shells.
+#    - Linux test execution (ubuntu runners only). Windows and macOS are NOT
+#      supported: every step here is bash-only AND the test-go job declares a
+#      Linux service container, which only runs on Linux runners. Do not add
+#      windows/macos runners without restructuring the job (separate no-services
+#      job) and adding shells.
 #    - Multiple Go version testing (primary, secondary)
 #    - Race detection and code coverage
 #    - Native CI mode for GitHub annotations and JSONL output
@@ -125,7 +127,7 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     steps:
-      - name: 🛑 Reject unsupported Windows runners
+      - name: 🛑 Reject unsupported non-Linux runners
         shell: bash
         env:
           # Route the matrix JSON through env: so it can't break out of the shell
@@ -139,29 +141,40 @@ jobs:
             exit 1
           fi
 
+          # Valid JSON isn't enough: a matrix must be an object. Guard here so a
+          # non-object (array/string/number) fails with this clear annotation instead
+          # of a raw jq indexing error in the extraction below.
+          if [[ "$(jq -r 'type' <<< "$TEST_MATRIX")" != "object" ]]; then
+            echo "::error title=Invalid test matrix::The test-matrix input must be a JSON object with an \"os\" array and/or an \"include\" array of entries containing \"os\"."
+            exit 1
+          fi
+
           # Collect every runner OS from both include-based and classic matrix shapes,
-          # then reject Windows: this workflow is bash-only and uses Linux service
-          # containers, so Windows runners are unsupported.
-          WINDOWS=$(jq -r '
+          # then reject any non-Linux runner. This workflow is bash-only AND the
+          # test-go job unconditionally declares a service container (redis, or a
+          # busybox placeholder when disabled). Service containers require Docker and
+          # only run on Linux runners, so a macOS or Windows leg would fail at job
+          # setup ("Initialize containers") before any step runs.
+          UNSUPPORTED=$(jq -r '
             [ (.include // [] | map(.os // empty)), (.os // []) ]
             | flatten
-            | map(select(type == "string" and (ascii_downcase | startswith("windows"))))
+            | map(select(type == "string" and (ascii_downcase | (startswith("windows") or startswith("macos")))))
             | unique | join(", ")
           ' <<< "$TEST_MATRIX")
 
-          if [[ -n "$WINDOWS" ]]; then
-            echo "::error title=Unsupported runner::Test matrix contains Windows runner(s): ${WINDOWS}. This workflow is bash-only and uses Linux service containers, so Windows is not supported. Use ubuntu-* runners (or macOS as PRIMARY_RUNNER/SECONDARY_RUNNER)."
-            echo "❌ Windows runners in matrix: ${WINDOWS}"
+          if [[ -n "$UNSUPPORTED" ]]; then
+            echo "::error title=Unsupported runner::Test matrix contains non-Linux runner(s): ${UNSUPPORTED}. This workflow is bash-only and uses a Linux service container, so only Linux (ubuntu-*) runners are supported. Set PRIMARY_RUNNER/SECONDARY_RUNNER to ubuntu-* runners."
+            echo "❌ Non-Linux runners in matrix: ${UNSUPPORTED}"
             exit 1
           fi
-          echo "✅ Test matrix contains no unsupported Windows runners."
+          echo "✅ Test matrix contains only supported Linux runners."
 
   # ----------------------------------------------------------------------------------
   # Testing Matrix for Go (Parallel)
   # ----------------------------------------------------------------------------------
   test-go:
     name: 🧪 Test (${{ matrix.name }})
-    needs: validate-matrix # Gate on preflight so Windows entries fail before service setup
+    needs: validate-matrix # Gate on preflight so non-Linux entries fail before service setup
     timeout-minutes: 30 # Prevent hung tests
     permissions:
       contents: read # Read repository content for testing


### PR DESCRIPTION
## What Changed

* **`.github/actions/setup-benchstat/action.yml`**: Replaced `sed`-based Go version parsing with anchored regex validation using `BASH_REMATCH`. The new logic explicitly rejects malformed inputs (e.g., "1.25junk", "127", "1.2z") instead of silently coercing them, matching the pattern used for `BENCHSTAT_LATEST_MIN_GO` validation.
* **`.github/env/10-mage-x.env`**: Updated `MAGE_X_VERSION` from `v1.26.3` to `v1.26.4` and `MAGE_X_STATICCHECK_VERSION` from `2026.2` to `2026.2.1`.
* **`.github/workflows/fortress-test-matrix.yml`**: Expanded runner validation to reject both Windows and macOS runners (previously only Windows). Updated documentation and error messages to clarify that only Linux (ubuntu-*) runners are supported due to bash-only steps and the required Linux service container. Added validation to ensure the test matrix input is a JSON object, not an array/string/number.

## Why It Was Necessary

* The `sed`-based Go version extraction silently accepted invalid inputs like "1.25junk" as valid version 1.25, creating potential for misconfiguration to go unnoticed.
* macOS runners are incompatible with this workflow because service containers (redis or placeholder) require Docker and only run on Linux runners, causing job setup failure before any steps execute.
* Updating mage-x and staticcheck versions ensures the workflow uses the latest tooling with bug fixes and improvements.

## Testing Performed

* Verified that the new regex-based Go version parser correctly rejects malformed version strings that the old `sed` logic would have accepted.
* Confirmed that the matrix validation logic correctly identifies and rejects both Windows and macOS runner entries from the test matrix JSON structure.
* Validated that the new JSON object type check prevents non-object inputs from causing cryptic jq indexing errors downstream.

## Impact / Risk

* **Low risk**: The Go version parsing change makes validation stricter and more explicit, catching configuration errors earlier rather than silently accepting invalid inputs.
* **Breaking change**: Any workflow configurations using macOS runners in `PRIMARY_RUNNER` or `SECONDARY_RUNNER` will now fail validation with a clear error message, requiring migration to ubuntu-* runners.
* **Improved reliability**: The enhanced validation prevents job failures at service container initialization by catching unsupported runner types during the preflight validation step.

<!-- go-broadcast-metadata
group:
  id: bitcoin-schema
  name: bitcoin-schema
diff_info:
  staged_repo_available: true
  changed_files_count: 3
  files_with_original_content: 3
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: d0f1a8f46110347182c5ec516cb5838d1881223c
  target_repo: BitcoinSchema/go-bitcoin
  sync_commit: de3ca194b4736386cdd9d742096fdc0a3ea4205c
  sync_time: 2026-08-22T12:18:24-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 310
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 716
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 312
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 1
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 414
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 257
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 594
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 770
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 397
performance:
  total_files: 102
-->
