### PR TITLE
refactor: Go 1.25 modernization, dedup, and test suite overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ View the generated [documentation](https://pkg.go.dev/github.com/bitcoinschema/g
 
 - **Addresses**
   - [Address from PrivateKey (ec.PrivateKey)](address.go)
+  - [Address from PubKey (ec.PublicKey)](address.go)
   - [Address from Script](address.go)
+  - [Validate a Base58 Address](address.go)
 - **Encryption**
   - [Encrypt With Private Key](encryption.go)
   - [Decrypt With Private Key](encryption.go)
@@ -150,11 +152,13 @@ View the generated [documentation](https://pkg.go.dev/github.com/bitcoinschema/g
 - **Signatures**
   - [Sign](sign.go) & [Verify a Bitcoin Message](verify.go)
   - [Verify a DER Signature](verify.go)
+  - [PubKey from a Signature](verify.go)
 - **Transactions**
   - [Calculate Fee](transaction.go)
   - [Create Tx](transaction.go)
   - [Create Tx using WIF](transaction.go)
   - [Create Tx with Change](transaction.go)
+  - [Create Tx with Change using WIF](transaction.go)
   - [Tx from Hex](transaction.go)
 
 <details>

--- a/address.go
+++ b/address.go
@@ -2,7 +2,6 @@ package bitcoin
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 
@@ -72,16 +71,10 @@ func (a *A25) ComputeChecksum() [4]byte {
 }
 
 // doubleSHA256 computes a double sha256 hash of the first 21 bytes of the
-// address.  This is the one function shared with the other bitcoin RC task.
-// Returned is the full 32 byte sha256 hash.  (The bitcoin checksum will be
-// the first four bytes of the slice.)
+// address.  Returned is the full 32 byte sha256 hash.  (The bitcoin checksum
+// will be the first four bytes of the slice.)
 func (a *A25) doubleSHA256() []byte {
-	h := sha256.New()
-	_, _ = h.Write(a[:21])
-	d := h.Sum([]byte{})
-	h = sha256.New()
-	_, _ = h.Write(d)
-	return h.Sum(d[:0])
+	return hash.Sha256d(a[:21])
 }
 
 // ValidA58 validates a base58 encoded bitcoin address.  An address is valid
@@ -160,7 +153,7 @@ func GetAddressFromPubKeyString(pubKey string, compressed, mainnet bool) (*bscri
 // GetAddressFromScript will take an output script and extract a standard bitcoin address
 func GetAddressFromScript(script string) (string, error) {
 	// No script?
-	if len(script) == 0 {
+	if script == "" {
 		return "", ErrMissingScript
 	}
 

--- a/address_test.go
+++ b/address_test.go
@@ -15,34 +15,37 @@ func TestValidA58(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedValid bool
 		expectedError bool
 	}{
-		{"1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi2", true, false},
-		{"1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, false},
-		{"1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
-		{"1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
-		{"1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
-		{"1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
-		{"1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
-		{"1KCEAmV", false, false},
-		{"", false, false},
-		{"0", false, true},
+		{"valid address", "1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi2", true, false},
+		{"invalid checksum", "1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, false},
+		{"too long 2x", "1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
+		{"too long 3x", "1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
+		{"too long 4x", "1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
+		{"too long 5x", "1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
+		{"too long 6x", "1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi", false, true},
+		{"too short", "1KCEAmV", false, false},
+		{caseEmpty, "", false, false},
+		{caseSingleZero, "0", false, true},
 		// Valid base58 testnet address (version 0x6f) decodes cleanly but is not version 0
-		{"mmobaZaCeFGujSmej9ESfohgfWjXBW1u7m", false, true},
+		{"testnet address not version 0", "mmobaZaCeFGujSmej9ESfohgfWjXBW1u7m", false, true},
 	}
 
 	for _, test := range tests {
-		if valid, err := ValidA58([]byte(test.input)); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		} else if valid && !test.expectedValid {
-			t.Fatalf("%s Failed: [%s] inputted and was valid but should NOT be valid", t.Name(), test.input)
-		} else if !valid && test.expectedValid {
-			t.Fatalf("%s Failed: [%s] inputted and was invalid but should be valid", t.Name(), test.input)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			valid, err := ValidA58([]byte(test.input))
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedValid, valid)
+		})
 	}
 }
 
@@ -63,7 +66,7 @@ func ExampleValidA58() {
 
 // BenchmarkValidA58 benchmarks the method ValidA58()
 func BenchmarkValidA58(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = ValidA58([]byte("1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi2"))
 	}
 }
@@ -73,27 +76,32 @@ func TestGetAddressFromPrivateKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name            string
 		input           string
 		expectedAddress string
 		compressed      bool
 		expectedError   bool
 	}{
-		{"0", "", true, true},
-		{"00000", "", true, true},
-		{"12345678", "1BHxe5Yw72oYoV8tFjySYrV9Y2JwMpAZEy", true, false},
-		{"54035dd4c7dda99ac473905a3d82", "1L5GmmuGeS3HwoEDv7zkWcheayXrRsurUm", true, false},
-		{"54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9", "13dnka5SaugRchayN84EED7a2E8dCNMLXQ", true, false},
-		{testPrivateKeyHex, "1DfGxKmgL3ETwUdNnXLBueEvNpjcDGcKgK", true, false},
+		{"invalid hex zero", "0", "", true, true},
+		{"invalid hex 00000", "00000", "", true, true},
+		{"short key 12345678", "12345678", "1BHxe5Yw72oYoV8tFjySYrV9Y2JwMpAZEy", true, false},
+		{"partial key 28 chars", "54035dd4c7dda99ac473905a3d82", "1L5GmmuGeS3HwoEDv7zkWcheayXrRsurUm", true, false},
+		{"partial key 58 chars", "54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9", "13dnka5SaugRchayN84EED7a2E8dCNMLXQ", true, false},
+		{"full private key", testPrivateKeyHex, "1DfGxKmgL3ETwUdNnXLBueEvNpjcDGcKgK", true, false},
 	}
 
 	for _, test := range tests {
-		if address, err := GetAddressFromPrivateKeyString(test.input, test.compressed, true); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		} else if address != test.expectedAddress {
-			t.Fatalf("%s Failed: [%s] inputted and [%s] expected, but got: %s", t.Name(), test.input, test.expectedAddress, address)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			address, err := GetAddressFromPrivateKeyString(test.input, test.compressed, true)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedAddress, address)
+		})
 	}
 }
 
@@ -152,7 +160,7 @@ func ExampleGetAddressFromPrivateKey() {
 // BenchmarkGetAddressFromPrivateKey benchmarks the method GetAddressFromPrivateKey()
 func BenchmarkGetAddressFromPrivateKey(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetAddressFromPrivateKeyString(key, true, true)
 	}
 }
@@ -171,36 +179,37 @@ func TestGetAddressFromPubKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name            string
 		input           *ec.PublicKey
 		expectedAddress string
 		expectedNil     bool
 		expectedError   bool
 	}{
-		{&ec.PublicKey{}, "", true, true},
-		{testGetPublicKeyFromPrivateKey(testPrivateKeyHex), "1DfGxKmgL3ETwUdNnXLBueEvNpjcDGcKgK", false, false},
-		{testGetPublicKeyFromPrivateKey("000000"), "15wJjXvfQzo3SXqoWGbWZmNYND1Si4siqV", false, false},
-		{testGetPublicKeyFromPrivateKey("0"), "15wJjXvfQzo3SXqoWGbWZmNYND1Si4siqV", true, true},
+		{"empty pubkey", &ec.PublicKey{}, "", true, true},
+		{"valid pubkey", testGetPublicKeyFromPrivateKey(testPrivateKeyHex), "1DfGxKmgL3ETwUdNnXLBueEvNpjcDGcKgK", false, false},
+		{"pubkey from 000000", testGetPublicKeyFromPrivateKey("000000"), "15wJjXvfQzo3SXqoWGbWZmNYND1Si4siqV", false, false},
+		{"nil pubkey from invalid key", testGetPublicKeyFromPrivateKey("0"), "15wJjXvfQzo3SXqoWGbWZmNYND1Si4siqV", true, true},
 	}
 
 	// todo: add more error cases of invalid *ec.PublicKey
 
 	for _, test := range tests {
-		rawKey, err := GetAddressFromPubKey(test.input, true, true)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		}
-		if rawKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if rawKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if rawKey != nil && rawKey.AddressString != test.expectedAddress {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but failed comparison of addresses, got: %s", t.Name(), test.input, test.expectedAddress, rawKey.AddressString)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			rawKey, err := GetAddressFromPubKey(test.input, true, true)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, rawKey)
+			} else {
+				require.NotNil(t, rawKey)
+				assert.Equal(t, test.expectedAddress, rawKey.AddressString)
+			}
+		})
 	}
 }
 
@@ -218,7 +227,7 @@ func ExampleGetAddressFromPubKey() {
 // BenchmarkGetAddressFromPubKey benchmarks the method GetAddressFromPubKey()
 func BenchmarkGetAddressFromPubKey(b *testing.B) {
 	pubKey := testGetPublicKeyFromPrivateKey(testPrivateKeyHex)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetAddressFromPubKey(pubKey, true, true)
 	}
 }
@@ -228,31 +237,36 @@ func TestGetAddressFromScript(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name            string
 		inputScript     string
 		expectedAddress string
 		expectedError   bool
 	}{
-		{"", "", true},
-		{"0", "", true},
-		{"76a9141a9d62736746f85ca872dc555ff51b1fed2471e288ac", "13Rj7G3pn2GgG8KE6SFXLc7dCJdLNnNK7M", false},
-		{"76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2996388ac", "1HRVqUGDzpZSMVuNSZxJVaB9xjneEShfA7", false},
-		{"76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2", "", true},
-		{"76a914b424110292f4ea2ac92beb9e83", "", true},
-		{"76a914b424110292f", "", true},
-		{"1HRVqUGDzpZSMVuNSZxJVaB9xjneEShfA7", "", true},
-		{"514104cc71eb30d653c0c3163990c47b976f3fb3f37cccdcbedb169a1dfef58bbfbfaff7d8a473e7e2e6d317b87bafe8bde97e3cf8f065dec022b51d11fcdd0d348ac4410461cbdcc5409fb4b4d42b51d33381354d80e550078cb532a34bfa2fcfdeb7d76519aecc62770f5b0e4ef8551946d8a540911abe3e7854a26f39f58b25c15342af52ae", "", true},
-		{"410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3", "", true},
-		{"47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901", "", true},
+		{"empty script", "", "", true},
+		{caseSingleZero, "0", "", true},
+		{"valid p2pkh 1", "76a9141a9d62736746f85ca872dc555ff51b1fed2471e288ac", "13Rj7G3pn2GgG8KE6SFXLc7dCJdLNnNK7M", false},
+		{"valid p2pkh 2", "76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2996388ac", "1HRVqUGDzpZSMVuNSZxJVaB9xjneEShfA7", false},
+		{"truncated script 1", "76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2", "", true},
+		{"truncated script 2", "76a914b424110292f4ea2ac92beb9e83", "", true},
+		{"truncated script 3", "76a914b424110292f", "", true},
+		{"address not script", "1HRVqUGDzpZSMVuNSZxJVaB9xjneEShfA7", "", true},
+		{"multisig script", "514104cc71eb30d653c0c3163990c47b976f3fb3f37cccdcbedb169a1dfef58bbfbfaff7d8a473e7e2e6d317b87bafe8bde97e3cf8f065dec022b51d11fcdd0d348ac4410461cbdcc5409fb4b4d42b51d33381354d80e550078cb532a34bfa2fcfdeb7d76519aecc62770f5b0e4ef8551946d8a540911abe3e7854a26f39f58b25c15342af52ae", "", true},
+		{"raw pubkey script", "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3", "", true},
+		{"signature script", "47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901", "", true},
 	}
 
 	for _, test := range tests {
-		if address, err := GetAddressFromScript(test.inputScript); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.inputScript, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.inputScript)
-		} else if address != test.expectedAddress {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but failed comparison of addresses, got: %s", t.Name(), test.inputScript, test.expectedAddress, address)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			address, err := GetAddressFromScript(test.inputScript)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedAddress, address)
+		})
 	}
 }
 
@@ -269,7 +283,7 @@ func ExampleGetAddressFromScript() {
 
 // BenchmarkAddressFromScript benchmarks the method GetAddressFromScript()
 func BenchmarkGetAddressFromScript(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetAddressFromScript("76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2996388ac")
 	}
 }
@@ -279,34 +293,35 @@ func TestGetAddressFromPubKeyString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name            string
 		input           string
 		expectedAddress string
 		expectedNil     bool
 		expectedError   bool
 	}{
-		{"", "", true, true},
-		{"0", "", true, true},
-		{"03ce8a73eb5e4d45966d719ac3ceb431cd0ee203e6395357a167b9abebc4baeacf", "17HeHWVDqDqexLJ31aG4qtVMoX8pKMGSuJ", false, false},
-		{"0000", "", true, true},
+		{caseEmpty, "", "", true, true},
+		{caseSingleZero, "0", "", true, true},
+		{"valid compressed pubkey", "03ce8a73eb5e4d45966d719ac3ceb431cd0ee203e6395357a167b9abebc4baeacf", "17HeHWVDqDqexLJ31aG4qtVMoX8pKMGSuJ", false, false},
+		{"invalid pubkey 0000", "0000", "", true, true},
 	}
 
 	for _, test := range tests {
-		rawKey, err := GetAddressFromPubKeyString(test.input, true, true)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		}
-		if rawKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if rawKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if rawKey != nil && rawKey.AddressString != test.expectedAddress {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but failed comparison of addresses, got: %s", t.Name(), test.input, test.expectedAddress, rawKey.AddressString)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			rawKey, err := GetAddressFromPubKeyString(test.input, true, true)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, rawKey)
+			} else {
+				require.NotNil(t, rawKey)
+				assert.Equal(t, test.expectedAddress, rawKey.AddressString)
+			}
+		})
 	}
 }
 
@@ -323,7 +338,7 @@ func ExampleGetAddressFromPubKeyString() {
 
 // BenchmarkGetAddressFromPubKeyString benchmarks the method GetAddressFromPubKeyString()
 func BenchmarkGetAddressFromPubKeyString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetAddressFromPubKeyString("03ce8a73eb5e4d45966d719ac3ceb431cd0ee203e6395357a167b9abebc4baeacf", true, true)
 	}
 }

--- a/coverage_gaps_test.go
+++ b/coverage_gaps_test.go
@@ -1,0 +1,62 @@
+package bitcoin
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultStandardFee verifies the default standard fee returned by DefaultStandardFee.
+func TestDefaultStandardFee(t *testing.T) {
+	t.Parallel()
+
+	fee := DefaultStandardFee()
+	require.NotNil(t, fee)
+	assert.Equal(t, bt.FeeTypeStandard, fee.FeeType)
+	assert.Equal(t, 5, fee.MiningFee.Satoshis)
+	assert.Equal(t, 10, fee.MiningFee.Bytes)
+	assert.Equal(t, 5, fee.RelayFee.Satoshis)
+	assert.Equal(t, 10, fee.RelayFee.Bytes)
+}
+
+// TestGenerateSharedKeyPair verifies that the shared key pair is symmetric: the
+// pair derived from (user1 private, user2 public) matches the pair derived from
+// (user2 private, user1 public).
+func TestGenerateSharedKeyPair(t *testing.T) {
+	t.Parallel()
+
+	user1, err := CreatePrivateKey()
+	require.NoError(t, err)
+
+	user2, err := CreatePrivateKey()
+	require.NoError(t, err)
+
+	priv1, pub1 := GenerateSharedKeyPair(user1, user2.PubKey())
+	require.NotNil(t, priv1)
+	require.NotNil(t, pub1)
+
+	priv2, pub2 := GenerateSharedKeyPair(user2, user1.PubKey())
+	require.NotNil(t, priv2)
+	require.NotNil(t, pub2)
+
+	// Both users derive the identical shared secret (ECDH symmetry)
+	assert.Equal(t, priv1.Serialize(), priv2.Serialize())
+	assert.Equal(t, pub1.Compressed(), pub2.Compressed())
+}
+
+// TestA25Accessors exercises the A25 address type accessors on a known-valid
+// mainnet address (version 0, self-consistent checksum).
+func TestA25Accessors(t *testing.T) {
+	t.Parallel()
+
+	var a A25
+	require.NoError(t, a.Set58([]byte("1KCEAmVS6FFggtc7W9as7sEENvjt7DqMi2")))
+
+	// Mainnet P2PKH addresses are version 0
+	assert.Equal(t, byte(0), a.Version())
+
+	// A valid address has a self-consistent checksum
+	assert.Equal(t, a.EmbeddedChecksum(), a.ComputeChecksum())
+}

--- a/ecies.go
+++ b/ecies.go
@@ -36,6 +36,14 @@ var (
 	ciphCoordLength = [2]byte{0x00, 0x20} //nolint:gochecknoglobals // fixed ECIES wire-format marker; byte arrays cannot be const
 )
 
+// deriveKeys splits SHA-512 of the ECDH shared secret into the AES-256-CBC
+// encryption key (keyE, first 32 bytes) and the HMAC-SHA-256 key (keyM, last 32
+// bytes), matching the Pyelliptic / ANSI X9.63 scheme.
+func deriveKeys(ecdhKey []byte) (keyE, keyM []byte) {
+	derivedKey := sha512.Sum512(ecdhKey)
+	return derivedKey[:32], derivedKey[32:]
+}
+
 // generateSharedSecret generates a shared secret based on a private key and a
 // public key using Diffie-Hellman key exchange (ECDH) (RFC 4753). RFC 5903
 // Section 9 states we should only return x.
@@ -68,9 +76,7 @@ func eciesEncrypt(pubKey *ec.PublicKey, in []byte) ([]byte, error) {
 		return nil, err
 	}
 	ecdhKey := generateSharedSecret(ephemeral, pubKey)
-	derivedKey := sha512.Sum512(ecdhKey)
-	keyE := derivedKey[:32]
-	keyM := derivedKey[32:]
+	keyE, keyM := deriveKeys(ecdhKey)
 
 	paddedIn := addPKCSPadding(in)
 	// IV + Curve params/X/Y + padded plaintext/ciphertext + HMAC-256
@@ -167,9 +173,7 @@ func eciesDecrypt(priv *ec.PrivateKey, in []byte) ([]byte, error) {
 
 	// generate shared secret
 	ecdhKey := generateSharedSecret(priv, pubKey)
-	derivedKey := sha512.Sum512(ecdhKey)
-	keyE := derivedKey[:32]
-	keyM := derivedKey[32:]
+	keyE, keyM := deriveKeys(ecdhKey)
 
 	// verify mac
 	hm := hmac.New(sha256.New, keyM)

--- a/ecies_test.go
+++ b/ecies_test.go
@@ -47,7 +47,7 @@ func TestEciesEncryptDecryptRoundTrip(t *testing.T) {
 		name string
 		data []byte
 	}{
-		{"empty", []byte("")},
+		{caseEmpty, []byte("")},
 		{"single space", []byte(" ")},
 		{"newline", []byte("\n")},
 		{"ascii", []byte("hello world")},
@@ -60,6 +60,7 @@ func TestEciesEncryptDecryptRoundTrip(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			encrypted, encErr := eciesEncrypt(priv.PubKey(), test.data)
 			require.NoError(t, encErr)
 			require.NotEmpty(t, encrypted)
@@ -140,11 +141,13 @@ func TestEciesDecryptFailures(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("too short", func(t *testing.T) {
+		t.Parallel()
 		_, decErr := eciesDecrypt(priv, make([]byte, 50))
 		require.ErrorIs(t, decErr, errInputTooShort)
 	})
 
 	t.Run("wrong private key", func(t *testing.T) {
+		t.Parallel()
 		other, keyErr := CreatePrivateKey()
 		require.NoError(t, keyErr)
 		_, decErr := eciesDecrypt(other, valid)
@@ -152,6 +155,7 @@ func TestEciesDecryptFailures(t *testing.T) {
 	})
 
 	t.Run("corrupted hmac", func(t *testing.T) {
+		t.Parallel()
 		corrupted := append([]byte(nil), valid...)
 		corrupted[len(corrupted)-1] ^= 0xff
 		_, decErr := eciesDecrypt(priv, corrupted)
@@ -159,6 +163,7 @@ func TestEciesDecryptFailures(t *testing.T) {
 	})
 
 	t.Run("bad curve marker", func(t *testing.T) {
+		t.Parallel()
 		corrupted := append([]byte(nil), valid...)
 		corrupted[16] ^= 0xff
 		_, decErr := eciesDecrypt(priv, corrupted)
@@ -166,6 +171,7 @@ func TestEciesDecryptFailures(t *testing.T) {
 	})
 
 	t.Run("bad X length", func(t *testing.T) {
+		t.Parallel()
 		corrupted := append([]byte(nil), valid...)
 		corrupted[18] ^= 0xff
 		_, decErr := eciesDecrypt(priv, corrupted)
@@ -173,6 +179,7 @@ func TestEciesDecryptFailures(t *testing.T) {
 	})
 
 	t.Run("bad Y length", func(t *testing.T) {
+		t.Parallel()
 		corrupted := append([]byte(nil), valid...)
 		corrupted[52] ^= 0xff
 		_, decErr := eciesDecrypt(priv, corrupted)
@@ -180,6 +187,7 @@ func TestEciesDecryptFailures(t *testing.T) {
 	})
 
 	t.Run("invalid curve point", func(t *testing.T) {
+		t.Parallel()
 		// Zero out the X (offset 20-51) and Y (offset 54-85) coordinates so the
 		// embedded public key does not lie on the secp256k1 curve.
 		corrupted := append([]byte(nil), valid...)
@@ -194,6 +202,7 @@ func TestEciesDecryptFailures(t *testing.T) {
 	})
 
 	t.Run("misaligned ciphertext length", func(t *testing.T) {
+		t.Parallel()
 		// Appending a single byte leaves the curve markers and point intact but
 		// makes the ciphertext length no longer a multiple of the AES block size.
 		corrupted := append(append([]byte(nil), valid...), 0x00)
@@ -233,6 +242,7 @@ func TestPKCSPadding(t *testing.T) {
 	}
 
 	t.Run("invalid padding", func(t *testing.T) {
+		t.Parallel()
 		// A full block whose final byte claims a padding length larger than the block.
 		bad := bytes.Repeat([]byte{0x20}, 16)
 		_, err := removePKCSPadding(bad)

--- a/encryption.go
+++ b/encryption.go
@@ -50,7 +50,7 @@ func EncryptWithPrivateKeyString(privateKey, data string) (string, error) {
 // DecryptWithPrivateKeyString is a convenience wrapper for DecryptWithPrivateKey()
 func DecryptWithPrivateKeyString(privateKey, data string) (string, error) {
 	// Get private key
-	rawPrivateKey, _, err := PrivateAndPublicKeys(privateKey)
+	rawPrivateKey, err := PrivateKeyFromString(privateKey)
 	if err != nil {
 		return "", err
 	}
@@ -75,11 +75,8 @@ func EncryptShared(user1PrivateKey *ec.PrivateKey, user2PubKey *ec.PublicKey, da
 func EncryptSharedString(user1PrivateKey *ec.PrivateKey, user2PubKey *ec.PublicKey, data string) (
 	*ec.PrivateKey, *ec.PublicKey, string, error,
 ) {
-	// Generate shared keys that can be decrypted by either user
-	sharedPrivKey, sharedPubKey := GenerateSharedKeyPair(user1PrivateKey, user2PubKey)
-
-	// Encrypt data with shared key
-	encryptedData, err := eciesEncrypt(sharedPubKey, []byte(data))
+	// Reuse EncryptShared and hex-encode the resulting payload
+	sharedPrivKey, sharedPubKey, encryptedData, err := EncryptShared(user1PrivateKey, user2PubKey, []byte(data))
 
 	return sharedPrivKey, sharedPubKey, hex.EncodeToString(encryptedData), err
 }

--- a/encryption_test.go
+++ b/encryption_test.go
@@ -22,29 +22,32 @@ func TestEncryptWithPrivateKey(t *testing.T) {
 	assert.NotNil(t, privateKey)
 
 	tests := []struct {
+		name          string
 		inputKey      *ec.PrivateKey
 		inputData     string
 		expectedError bool
 	}{
-		{privateKey, "", false},
-		{privateKey, " ", false},
-		{privateKey, "\n", false},
-		{privateKey, "0", false},
-		{privateKey, "-1", false},
-		{privateKey, "test-data", false},
-		{privateKey, `{"json":"data"}`, false},
-		{privateKey, `PLXfZ8ZNN9emRVLapZlvsDpjti3TazobtrY1LWibG5ogf07R5u6xwTGSsBGH10E5naTJLOhj38dFFDeG7giLIvK9QbiF8xSqbXoxvILl09AeXSFfOx7154KdOQdoXMxsghUFi91Efh4uWNl53d7feec7NXh7WrRk68sYUQrfGNdvgxyJlYXBpp7pq5f9Yhhm2TxbNyTyh4dkgvXVJtVfFLwiOWYfO9PAwmfDAgoFyP1vpNcL7G2lCsDW2LuaO1PO0L8a0Z55jpqYrYwzUG3IK4HKnx61xWvawFSzapzGLMrrdxVK56WuToZPOVlLpXjGKYNXlfBXh6T4d1uYUQg9aKfrdIZWCXjVnCXrqDa8vrF0djypIPq24zE0KM0oQZfQJT2Vptu1OPJkes2nIpAUTKxtiLIiunbk8EXaRFBAgGYFFHYm3tHLQUaFQ0K6USoTN3Nr92SjgKUcXVJtSeH854fFpSAoi8je74XPLFHU54GJ0LB3ixHFmD1YQFbBJux7738gI05pxZTwl69KXoat8OfFamLhwNxg8BcA8GXpkN6i5UZW8VfvOQ11nfpd5RykehgYeFyZaewUizPTZkVfI8BT5fdBGQAGXfNT8Xo0OiRxb64rB3Q3YcKiwXjpD1gc14vZXb5EzP6y274yh9RODHPi3rZuVYeGDBd1woFHng2cFeu1ZZ1kBpB30jqqoxDvYzHWvUEpeP3mRyyL51pqYECgOoTEB9nZlb8J31sbAAyY5EXGp6mPuxnhYfR03wIPdkVaDgY9IUdBfKxiIfghTw9Zk9NYZWz1THnqe1GfnBqtHTWiHHuBt0vEJ5QNiMyvcsZbLb6djbbtVFV5sEMzRWf8cJInSEQFgcXPRFaZYow2bJiugFTGvt0ZZKscHqn2SJFNKGRgr3zlcTgF3Y33PVJVTg1uOaZw6y6mbVituSAR5LuDN0zlFuvkOvr63Hys3fE4dONIOxphiDyNG0Nvci5I3bB3E1H1gT8vUDCq`, false},
+		{"empty data", privateKey, "", false},
+		{"single space", privateKey, " ", false},
+		{"newline", privateKey, "\n", false},
+		{"zero string", privateKey, "0", false},
+		{"negative string", privateKey, "-1", false},
+		{"test-data", privateKey, "test-data", false},
+		{"json data", privateKey, `{"json":"data"}`, false},
+		{"large payload", privateKey, `PLXfZ8ZNN9emRVLapZlvsDpjti3TazobtrY1LWibG5ogf07R5u6xwTGSsBGH10E5naTJLOhj38dFFDeG7giLIvK9QbiF8xSqbXoxvILl09AeXSFfOx7154KdOQdoXMxsghUFi91Efh4uWNl53d7feec7NXh7WrRk68sYUQrfGNdvgxyJlYXBpp7pq5f9Yhhm2TxbNyTyh4dkgvXVJtVfFLwiOWYfO9PAwmfDAgoFyP1vpNcL7G2lCsDW2LuaO1PO0L8a0Z55jpqYrYwzUG3IK4HKnx61xWvawFSzapzGLMrrdxVK56WuToZPOVlLpXjGKYNXlfBXh6T4d1uYUQg9aKfrdIZWCXjVnCXrqDa8vrF0djypIPq24zE0KM0oQZfQJT2Vptu1OPJkes2nIpAUTKxtiLIiunbk8EXaRFBAgGYFFHYm3tHLQUaFQ0K6USoTN3Nr92SjgKUcXVJtSeH854fFpSAoi8je74XPLFHU54GJ0LB3ixHFmD1YQFbBJux7738gI05pxZTwl69KXoat8OfFamLhwNxg8BcA8GXpkN6i5UZW8VfvOQ11nfpd5RykehgYeFyZaewUizPTZkVfI8BT5fdBGQAGXfNT8Xo0OiRxb64rB3Q3YcKiwXjpD1gc14vZXb5EzP6y274yh9RODHPi3rZuVYeGDBd1woFHng2cFeu1ZZ1kBpB30jqqoxDvYzHWvUEpeP3mRyyL51pqYECgOoTEB9nZlb8J31sbAAyY5EXGp6mPuxnhYfR03wIPdkVaDgY9IUdBfKxiIfghTw9Zk9NYZWz1THnqe1GfnBqtHTWiHHuBt0vEJ5QNiMyvcsZbLb6djbbtVFV5sEMzRWf8cJInSEQFgcXPRFaZYow2bJiugFTGvt0ZZKscHqn2SJFNKGRgr3zlcTgF3Y33PVJVTg1uOaZw6y6mbVituSAR5LuDN0zlFuvkOvr63Hys3fE4dONIOxphiDyNG0Nvci5I3bB3E1H1gT8vUDCq`, false},
 	}
 
-	var encrypted string
 	for _, test := range tests {
-		if encrypted, err = EncryptWithPrivateKey(test.inputKey, test.inputData); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error not expected but got: %s", t.Name(), test.inputKey, test.inputData, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error was expected", t.Name(), test.inputKey, test.inputData)
-		} else if len(encrypted) == 0 {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and expected length > 0, but got: 0", t.Name(), test.inputKey, test.inputData)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			encrypted, err := EncryptWithPrivateKey(test.inputKey, test.inputData)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, encrypted)
+			}
+		})
 	}
 }
 
@@ -86,7 +89,7 @@ func ExampleEncryptWithPrivateKey() {
 // BenchmarkEncryptWithPrivateKey benchmarks the method EncryptWithPrivateKey()
 func BenchmarkEncryptWithPrivateKey(b *testing.B) {
 	key, _ := CreatePrivateKey()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = EncryptWithPrivateKey(key, "some-data")
 	}
 }
@@ -101,30 +104,33 @@ func TestEncryptWithPrivateKeyString(t *testing.T) {
 	assert.NotNil(t, privateKey)
 
 	tests := []struct {
+		name          string
 		inputKey      string
 		inputData     string
 		expectedError bool
 	}{
-		{"", "", true},
-		{privateKey, "", false},
-		{privateKey, " ", false},
-		{privateKey, "\n", false},
-		{privateKey, "0", false},
-		{privateKey, "-1", false},
-		{privateKey, "test-data", false},
-		{privateKey, `{"json":"data"}`, false},
-		{privateKey, `PLXfZ8ZNN9emRVLapZlvsDpjti3TazobtrY1LWibG5ogf07R5u6xwTGSsBGH10E5naTJLOhj38dFFDeG7giLIvK9QbiF8xSqbXoxvILl09AeXSFfOx7154KdOQdoXMxsghUFi91Efh4uWNl53d7feec7NXh7WrRk68sYUQrfGNdvgxyJlYXBpp7pq5f9Yhhm2TxbNyTyh4dkgvXVJtVfFLwiOWYfO9PAwmfDAgoFyP1vpNcL7G2lCsDW2LuaO1PO0L8a0Z55jpqYrYwzUG3IK4HKnx61xWvawFSzapzGLMrrdxVK56WuToZPOVlLpXjGKYNXlfBXh6T4d1uYUQg9aKfrdIZWCXjVnCXrqDa8vrF0djypIPq24zE0KM0oQZfQJT2Vptu1OPJkes2nIpAUTKxtiLIiunbk8EXaRFBAgGYFFHYm3tHLQUaFQ0K6USoTN3Nr92SjgKUcXVJtSeH854fFpSAoi8je74XPLFHU54GJ0LB3ixHFmD1YQFbBJux7738gI05pxZTwl69KXoat8OfFamLhwNxg8BcA8GXpkN6i5UZW8VfvOQ11nfpd5RykehgYeFyZaewUizPTZkVfI8BT5fdBGQAGXfNT8Xo0OiRxb64rB3Q3YcKiwXjpD1gc14vZXb5EzP6y274yh9RODHPi3rZuVYeGDBd1woFHng2cFeu1ZZ1kBpB30jqqoxDvYzHWvUEpeP3mRyyL51pqYECgOoTEB9nZlb8J31sbAAyY5EXGp6mPuxnhYfR03wIPdkVaDgY9IUdBfKxiIfghTw9Zk9NYZWz1THnqe1GfnBqtHTWiHHuBt0vEJ5QNiMyvcsZbLb6djbbtVFV5sEMzRWf8cJInSEQFgcXPRFaZYow2bJiugFTGvt0ZZKscHqn2SJFNKGRgr3zlcTgF3Y33PVJVTg1uOaZw6y6mbVituSAR5LuDN0zlFuvkOvr63Hys3fE4dONIOxphiDyNG0Nvci5I3bB3E1H1gT8vUDCq`, false},
+		{"empty key errors", "", "", true},
+		{"empty data", privateKey, "", false},
+		{"single space", privateKey, " ", false},
+		{"newline", privateKey, "\n", false},
+		{"zero string", privateKey, "0", false},
+		{"negative string", privateKey, "-1", false},
+		{"test-data", privateKey, "test-data", false},
+		{"json data", privateKey, `{"json":"data"}`, false},
+		{"large payload", privateKey, `PLXfZ8ZNN9emRVLapZlvsDpjti3TazobtrY1LWibG5ogf07R5u6xwTGSsBGH10E5naTJLOhj38dFFDeG7giLIvK9QbiF8xSqbXoxvILl09AeXSFfOx7154KdOQdoXMxsghUFi91Efh4uWNl53d7feec7NXh7WrRk68sYUQrfGNdvgxyJlYXBpp7pq5f9Yhhm2TxbNyTyh4dkgvXVJtVfFLwiOWYfO9PAwmfDAgoFyP1vpNcL7G2lCsDW2LuaO1PO0L8a0Z55jpqYrYwzUG3IK4HKnx61xWvawFSzapzGLMrrdxVK56WuToZPOVlLpXjGKYNXlfBXh6T4d1uYUQg9aKfrdIZWCXjVnCXrqDa8vrF0djypIPq24zE0KM0oQZfQJT2Vptu1OPJkes2nIpAUTKxtiLIiunbk8EXaRFBAgGYFFHYm3tHLQUaFQ0K6USoTN3Nr92SjgKUcXVJtSeH854fFpSAoi8je74XPLFHU54GJ0LB3ixHFmD1YQFbBJux7738gI05pxZTwl69KXoat8OfFamLhwNxg8BcA8GXpkN6i5UZW8VfvOQ11nfpd5RykehgYeFyZaewUizPTZkVfI8BT5fdBGQAGXfNT8Xo0OiRxb64rB3Q3YcKiwXjpD1gc14vZXb5EzP6y274yh9RODHPi3rZuVYeGDBd1woFHng2cFeu1ZZ1kBpB30jqqoxDvYzHWvUEpeP3mRyyL51pqYECgOoTEB9nZlb8J31sbAAyY5EXGp6mPuxnhYfR03wIPdkVaDgY9IUdBfKxiIfghTw9Zk9NYZWz1THnqe1GfnBqtHTWiHHuBt0vEJ5QNiMyvcsZbLb6djbbtVFV5sEMzRWf8cJInSEQFgcXPRFaZYow2bJiugFTGvt0ZZKscHqn2SJFNKGRgr3zlcTgF3Y33PVJVTg1uOaZw6y6mbVituSAR5LuDN0zlFuvkOvr63Hys3fE4dONIOxphiDyNG0Nvci5I3bB3E1H1gT8vUDCq`, false},
 	}
 
-	var encrypted string
 	for _, test := range tests {
-		if encrypted, err = EncryptWithPrivateKeyString(test.inputKey, test.inputData); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error not expected but got: %s", t.Name(), test.inputKey, test.inputData, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error was expected", t.Name(), test.inputKey, test.inputData)
-		} else if err == nil && len(encrypted) == 0 {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and expected length > 0, but got: 0", t.Name(), test.inputKey, test.inputData)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			encrypted, err := EncryptWithPrivateKeyString(test.inputKey, test.inputData)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, encrypted)
+			}
+		})
 	}
 }
 
@@ -156,7 +162,7 @@ func ExampleEncryptWithPrivateKeyString() {
 // BenchmarkEncryptWithPrivateKeyString benchmarks the method EncryptWithPrivateKeyString()
 func BenchmarkEncryptWithPrivateKeyString(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = EncryptWithPrivateKeyString(key, "some-data")
 	}
 }
@@ -171,72 +177,84 @@ func TestDecryptWithPrivateKey(t *testing.T) {
 	assert.NotNil(t, privateKey)
 
 	tests := []struct {
+		name           string
 		inputKey       *ec.PrivateKey
 		inputEncrypted string
 		expectedData   string
 		expectedError  bool
 	}{
 		{
+			"empty ciphertext errors",
 			privateKey,
 			"",
 			"",
 			true,
 		},
 		{
+			"invalid hex errors",
 			privateKey,
 			"0",
 			"",
 			true,
 		},
 		{
+			"too short errors",
 			privateKey,
 			"176984bb2f54bfe6275e2d52c8de3d42",
 			"",
 			true,
 		},
 		{
+			"decrypts empty string",
 			privateKey,
 			"7bea44d59dca4a95f179f9852d511e0f02ca0020961bd9266174d5275c11abd7f0efc19905c04199893ab784e70a7e01f4856b4e0020259296d1bceb4a8ad5267f5633366de03e45d5e7d29754cb35289409c96ec2256a5976bdd8e866f2640b5091b319385f02d59fb89f9d4c0790c70098d142e2a47139671bc4c775e22e5bee59e2310f9b",
 			"",
 			false,
 		},
 		{
+			"decrypts space",
 			privateKey,
 			"8372c24e143fad68496b970f52c971a102ca0020184e2516b9c6ec25873332795f6ae286ec498f72e1879a1b4a6178adbb167d2700204ffc66b0afc2c5e7ca860322f2684ac329901452ec879f5d36ff874285d3a1d77f860da05d454fcb3dc0bc2a880419d0a261236cdd2bf6946e4d2b426c5327bb2e06020b48866730147fc6cac2befdb0",
 			" ",
 			false,
 		},
 		{
+			"decrypts newline",
 			privateKey,
 			"4bf9002dacbe9bd7cfeef112f90f1f3202ca0020b3ae7e409189c4fefc92d30dada67dbe6c25eb9bfcc7a0a1078fcafeb355704c00201533cfe68aeaee68caa0d502d7884acfa42101fd2ef5a933a7bcb08812e9795f3ae8913a72a92cfc5c2f4ab2f09903e2d13fde409df0f8395a474bae9a2d6f5f570b5a885dfbc1ea4a31861ccd6cf559",
 			"\n",
 			false,
 		},
 		{
+			"decrypts zero string",
 			privateKey,
 			"2a7da26bfd1dd55b448c1ce080365fb702ca002074a0063668f26ef3a9371d3043548e44059c4653ea0d7971739d3c122066e1990020084e47d2a2d7a7fca332eb9ea05e981a363ac30f4826fddfef897f5be95f81edb5344b66d884956d23b643ae70ca2f0c1c81f9b81b674920ae4ded7669713ad6f6c3ea0416f020e36b651c68d1c5940f",
 			"0",
 			false,
 		},
 		{
+			"decrypts negative string",
 			privateKey,
 			"07b4c9a606c2fbe56247847ad2eaf38d02ca0020907673758a824ad6040d699a20e08fb99147908453453a5bc566f52581dd7f390020dc2827b4c12c765ee1c32eb8600feb325ca12bbe81fa41ecd853b3f54b3294e351e0f7b60c353a146bc43e9c0f682af1ee441b3b1bd3b06088de36f933ed7bfeab2c58af1ee5ab7ca9c02d688dee887b",
 			"-1",
 			false,
 		},
 		{
+			"decrypts test-data",
 			privateKey,
 			"4fab3e3534e101cef1ec936628894a2c02ca00206b60babbfa6ccac9a8078d55a50a32b5e15b1a3c9a3607499066bc4eb70721f4002005cdc7638c7e6c051be80cc83092ed5af5a9a015e24c3ed4af289d59c0c65cb608aa8f07c9318e6e52a18e60dbcf7a5889304f4bfc01cad735a5f2279f06eb5da5ed7454320da87becbdcd889708fcab",
 			"test-data",
 			false,
 		},
 		{
+			"decrypts json",
 			privateKey,
 			"b644c914ce076f88a3ae57ae2726632a02ca002019c1f3296eb7b2e6a909c5efb419b031712e75ca32299e98cc7ea84f7be0ff6e00204b811188d218a0a1839ab11a07d27b4755e92dd730ec044629b9b34dbc0193ab5de4cd3cef9e3c9fdc446664d97644137b1df3cccbca47bc190a3ba41f0805fc4eb2e74d458ec67437cb07ac7d61af75",
 			`{"json":"data"}`,
 			false,
 		},
 		{
+			"decrypts large payload",
 			privateKey,
 			"b157ee308057c09700f91d6007ec52b802ca0020ca9a8f5267e9e14b141aa9269132a13f119919887ca5d78e1231466bde29f00400208143ed3063b295d90cc76e8e270328e59b390a824fb0c3034f7a8aa3c71716595db36debc32faafb709712413ce2771c384cd2de265cd10a05d6eeb3a806825f20a153bfd298a8e91c158f7b3a8abd2bfe7595f0ba5c2690170f7b725edd28aa60aa4c9e0e7b84c15d6b06222cb0ca3a19fc5a82361002cfd528e9ede4b68a2a3eb0b500536ed2890373e4a5aa55c2ffee3e0da4b2c32657cb03b9c7f51a4baead7d5915076a3db6f3c8b64688b44dfe8d70d4c96ac4c1d06e63dd66a27cbd493b5408eed21e68dc691ba9c23d87740f2352af53f4a0dc080d39c483a09a3299c846aea6fff88602f04a960c8b1fc889cd4bf26365159bdab537004ab74bc81cae4d8fae0616beb0ee9e7dd10255132afd6d326a9e961aba3d2d0efe49b87c8831d13c6ff9503a428e3e646cd5a3239d2e138446a1ca2592b8fb6b8cb19cf91db0e46bcb5e9abe9ac5afd2d1e654e85c7da098ed094b7291ec229767d5636b06796072222ad6f87d3ad3e3b6529fd6a1b8e873f90f5a2aa992e4fc0ec930cb22be95895bb955f8853ab40117b697e70830763cfb9b755278d1a3f9581bf54a81228eb6dfc83d99508c05264cbaab88be2f78fa78aa3e2e86bc893250c7370d8b80d88b5d18a7c43e0f123ea00a44b42c86857e317250fbdc990261ea2f42f5380782cf3056caf66a61eb9ebb3bf43867d230b8415a34832f5072c9e12db7caa0ef7c032b079cbdbdfcda2eb9397e3f7febc11d172b7659732faa0aa95c84a4c4162d043f5fa3fce3788ac2ad5cf4cb5d2a8f82e36273e091c8480a3e5d3c35e01e2e61f4b33d66f3b49f62dc005fa3d55e25157dceecc7b58bf43b36ebf0bea610aa016ec57f9dfc9fd97c9b006fcf6bd2530a231f983bfb430c867f05dfa599eea8720a9ae9829b8b63cdec57766940e1c663966c2d557d2fdb80d67a2d928a929dce84af6b596aecd5cebb0cc21a2dd3bc08c6c48b455e71cac3d863f9c4e1a847b31c2d86ab6b8a691cfdc2d3c0f367d253e9ea0c6668125ae1640434eb6d14d095a128537019f387e9e7af1d85a35fe0139d0949bb67e2d1fd3a3b747f7faaa42de02fcc2ceb0df79ccf2e743f8d5099b222f537dd6c146ca7a54bea4e7fc2cdf99f61055817c296c8fab8ff5f242ff31a5853e7d204007e77265e773001de335d520009861246cbbfbdbb4ef1bbf6aaad1e80dadac0415717b633fc04d3fd0d7217a6d47d38b234e832856e2dd1b2c8ab5ba8c23620ccb82236f1ca227cbef4d59cdd58dcdb4ae2e1efae725eff755c7b929190bda4fa9a80a1d752cb5a23174977badceb2ab0a30a64337f46c903e6ae2906f096d6fe475cbd6742d67871fb58bf3c71d598d6f0f6433c1818a3424758acda5d505d815686c0ab43f9c0e783dfa9f918fecc2b831210812c34606b4f3c1ae55853cabe2cc07ea0e97897446d37606ee097c72e3173213774df1539372fadff75e1bef84d9c2d3de2a22d67e416fb23dbddd74a96ec51b4394225",
 			`PLXfZ8ZNN9emRVLapZlvsDpjti3TazobtrY1LWibG5ogf07R5u6xwTGSsBGH10E5naTJLOhj38dFFDeG7giLIvK9QbiF8xSqbXoxvILl09AeXSFfOx7154KdOQdoXMxsghUFi91Efh4uWNl53d7feec7NXh7WrRk68sYUQrfGNdvgxyJlYXBpp7pq5f9Yhhm2TxbNyTyh4dkgvXVJtVfFLwiOWYfO9PAwmfDAgoFyP1vpNcL7G2lCsDW2LuaO1PO0L8a0Z55jpqYrYwzUG3IK4HKnx61xWvawFSzapzGLMrrdxVK56WuToZPOVlLpXjGKYNXlfBXh6T4d1uYUQg9aKfrdIZWCXjVnCXrqDa8vrF0djypIPq24zE0KM0oQZfQJT2Vptu1OPJkes2nIpAUTKxtiLIiunbk8EXaRFBAgGYFFHYm3tHLQUaFQ0K6USoTN3Nr92SjgKUcXVJtSeH854fFpSAoi8je74XPLFHU54GJ0LB3ixHFmD1YQFbBJux7738gI05pxZTwl69KXoat8OfFamLhwNxg8BcA8GXpkN6i5UZW8VfvOQ11nfpd5RykehgYeFyZaewUizPTZkVfI8BT5fdBGQAGXfNT8Xo0OiRxb64rB3Q3YcKiwXjpD1gc14vZXb5EzP6y274yh9RODHPi3rZuVYeGDBd1woFHng2cFeu1ZZ1kBpB30jqqoxDvYzHWvUEpeP3mRyyL51pqYECgOoTEB9nZlb8J31sbAAyY5EXGp6mPuxnhYfR03wIPdkVaDgY9IUdBfKxiIfghTw9Zk9NYZWz1THnqe1GfnBqtHTWiHHuBt0vEJ5QNiMyvcsZbLb6djbbtVFV5sEMzRWf8cJInSEQFgcXPRFaZYow2bJiugFTGvt0ZZKscHqn2SJFNKGRgr3zlcTgF3Y33PVJVTg1uOaZw6y6mbVituSAR5LuDN0zlFuvkOvr63Hys3fE4dONIOxphiDyNG0Nvci5I3bB3E1H1gT8vUDCq`,
@@ -244,15 +262,17 @@ func TestDecryptWithPrivateKey(t *testing.T) {
 		},
 	}
 
-	var decrypted string
 	for _, test := range tests {
-		if decrypted, err = DecryptWithPrivateKey(test.inputKey, test.inputEncrypted); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error not expected but got: %s", t.Name(), test.inputKey, test.inputEncrypted, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error was expected", t.Name(), test.inputKey, test.inputEncrypted)
-		} else if decrypted != test.expectedData {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and [%s] expected, but got: %s", t.Name(), test.inputKey, test.inputEncrypted, test.expectedData, decrypted)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			decrypted, err := DecryptWithPrivateKey(test.inputKey, test.inputEncrypted)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedData, decrypted)
+			}
+		})
 	}
 }
 
@@ -282,7 +302,7 @@ func ExampleDecryptWithPrivateKey() {
 // BenchmarkDecryptWithPrivateKey benchmarks the method DecryptWithPrivateKey()
 func BenchmarkDecryptWithPrivateKey(b *testing.B) {
 	key, _ := PrivateKeyFromString("bb66a48a9f6dd7b8fb469a6f08a75c25770591dc509c72129b2aaeca77a5269e")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = DecryptWithPrivateKey(key, "4fab3e3534e101cef1ec936628894a2c02ca00206b60babbfa6cc"+
 			"ac9a8078d55a50a32b5e15b1a3c9a3607499066bc4eb70721f4002005cdc7638c7e6c051be80cc83092ed5af5a9a015e24c3ed4af289d59"+
 			"c0c65cb608aa8f07c9318e6e52a18e60dbcf7a5889304f4bfc01cad735a5f2279f06eb5da5ed7454320da87becbdcd889708fcab")
@@ -297,84 +317,98 @@ func TestDecryptWithPrivateKeyString(t *testing.T) {
 	privateKey := "bb66a48a9f6dd7b8fb469a6f08a75c25770591dc509c72129b2aaeca77a5269e"
 
 	tests := []struct {
+		name           string
 		inputKey       string
 		inputEncrypted string
 		expectedData   string
 		expectedError  bool
 	}{
 		{
+			"empty key errors",
 			"",
 			"",
 			"",
 			true,
 		},
 		{
+			"invalid key errors",
 			"0",
 			"",
 			"",
 			true,
 		},
 		{
+			"empty ciphertext errors",
 			privateKey,
 			"",
 			"",
 			true,
 		},
 		{
+			"invalid hex errors",
 			privateKey,
 			"0",
 			"",
 			true,
 		},
 		{
+			"too short errors",
 			privateKey,
 			"176984bb2f54bfe6275e2d52c8de3d42",
 			"",
 			true,
 		},
 		{
+			"decrypts empty string",
 			privateKey,
 			"7bea44d59dca4a95f179f9852d511e0f02ca0020961bd9266174d5275c11abd7f0efc19905c04199893ab784e70a7e01f4856b4e0020259296d1bceb4a8ad5267f5633366de03e45d5e7d29754cb35289409c96ec2256a5976bdd8e866f2640b5091b319385f02d59fb89f9d4c0790c70098d142e2a47139671bc4c775e22e5bee59e2310f9b",
 			"",
 			false,
 		},
 		{
+			"decrypts space",
 			privateKey,
 			"8372c24e143fad68496b970f52c971a102ca0020184e2516b9c6ec25873332795f6ae286ec498f72e1879a1b4a6178adbb167d2700204ffc66b0afc2c5e7ca860322f2684ac329901452ec879f5d36ff874285d3a1d77f860da05d454fcb3dc0bc2a880419d0a261236cdd2bf6946e4d2b426c5327bb2e06020b48866730147fc6cac2befdb0",
 			" ",
 			false,
 		},
 		{
+			"decrypts newline",
 			privateKey,
 			"4bf9002dacbe9bd7cfeef112f90f1f3202ca0020b3ae7e409189c4fefc92d30dada67dbe6c25eb9bfcc7a0a1078fcafeb355704c00201533cfe68aeaee68caa0d502d7884acfa42101fd2ef5a933a7bcb08812e9795f3ae8913a72a92cfc5c2f4ab2f09903e2d13fde409df0f8395a474bae9a2d6f5f570b5a885dfbc1ea4a31861ccd6cf559",
 			"\n",
 			false,
 		},
 		{
+			"decrypts zero string",
 			privateKey,
 			"2a7da26bfd1dd55b448c1ce080365fb702ca002074a0063668f26ef3a9371d3043548e44059c4653ea0d7971739d3c122066e1990020084e47d2a2d7a7fca332eb9ea05e981a363ac30f4826fddfef897f5be95f81edb5344b66d884956d23b643ae70ca2f0c1c81f9b81b674920ae4ded7669713ad6f6c3ea0416f020e36b651c68d1c5940f",
 			"0",
 			false,
 		},
 		{
+			"decrypts negative string",
 			privateKey,
 			"07b4c9a606c2fbe56247847ad2eaf38d02ca0020907673758a824ad6040d699a20e08fb99147908453453a5bc566f52581dd7f390020dc2827b4c12c765ee1c32eb8600feb325ca12bbe81fa41ecd853b3f54b3294e351e0f7b60c353a146bc43e9c0f682af1ee441b3b1bd3b06088de36f933ed7bfeab2c58af1ee5ab7ca9c02d688dee887b",
 			"-1",
 			false,
 		},
 		{
+			"decrypts test-data",
 			privateKey,
 			"4fab3e3534e101cef1ec936628894a2c02ca00206b60babbfa6ccac9a8078d55a50a32b5e15b1a3c9a3607499066bc4eb70721f4002005cdc7638c7e6c051be80cc83092ed5af5a9a015e24c3ed4af289d59c0c65cb608aa8f07c9318e6e52a18e60dbcf7a5889304f4bfc01cad735a5f2279f06eb5da5ed7454320da87becbdcd889708fcab",
 			"test-data",
 			false,
 		},
 		{
+			"decrypts json",
 			privateKey,
 			"b644c914ce076f88a3ae57ae2726632a02ca002019c1f3296eb7b2e6a909c5efb419b031712e75ca32299e98cc7ea84f7be0ff6e00204b811188d218a0a1839ab11a07d27b4755e92dd730ec044629b9b34dbc0193ab5de4cd3cef9e3c9fdc446664d97644137b1df3cccbca47bc190a3ba41f0805fc4eb2e74d458ec67437cb07ac7d61af75",
 			`{"json":"data"}`,
 			false,
 		},
 		{
+			"decrypts large payload",
 			privateKey,
 			"b157ee308057c09700f91d6007ec52b802ca0020ca9a8f5267e9e14b141aa9269132a13f119919887ca5d78e1231466bde29f00400208143ed3063b295d90cc76e8e270328e59b390a824fb0c3034f7a8aa3c71716595db36debc32faafb709712413ce2771c384cd2de265cd10a05d6eeb3a806825f20a153bfd298a8e91c158f7b3a8abd2bfe7595f0ba5c2690170f7b725edd28aa60aa4c9e0e7b84c15d6b06222cb0ca3a19fc5a82361002cfd528e9ede4b68a2a3eb0b500536ed2890373e4a5aa55c2ffee3e0da4b2c32657cb03b9c7f51a4baead7d5915076a3db6f3c8b64688b44dfe8d70d4c96ac4c1d06e63dd66a27cbd493b5408eed21e68dc691ba9c23d87740f2352af53f4a0dc080d39c483a09a3299c846aea6fff88602f04a960c8b1fc889cd4bf26365159bdab537004ab74bc81cae4d8fae0616beb0ee9e7dd10255132afd6d326a9e961aba3d2d0efe49b87c8831d13c6ff9503a428e3e646cd5a3239d2e138446a1ca2592b8fb6b8cb19cf91db0e46bcb5e9abe9ac5afd2d1e654e85c7da098ed094b7291ec229767d5636b06796072222ad6f87d3ad3e3b6529fd6a1b8e873f90f5a2aa992e4fc0ec930cb22be95895bb955f8853ab40117b697e70830763cfb9b755278d1a3f9581bf54a81228eb6dfc83d99508c05264cbaab88be2f78fa78aa3e2e86bc893250c7370d8b80d88b5d18a7c43e0f123ea00a44b42c86857e317250fbdc990261ea2f42f5380782cf3056caf66a61eb9ebb3bf43867d230b8415a34832f5072c9e12db7caa0ef7c032b079cbdbdfcda2eb9397e3f7febc11d172b7659732faa0aa95c84a4c4162d043f5fa3fce3788ac2ad5cf4cb5d2a8f82e36273e091c8480a3e5d3c35e01e2e61f4b33d66f3b49f62dc005fa3d55e25157dceecc7b58bf43b36ebf0bea610aa016ec57f9dfc9fd97c9b006fcf6bd2530a231f983bfb430c867f05dfa599eea8720a9ae9829b8b63cdec57766940e1c663966c2d557d2fdb80d67a2d928a929dce84af6b596aecd5cebb0cc21a2dd3bc08c6c48b455e71cac3d863f9c4e1a847b31c2d86ab6b8a691cfdc2d3c0f367d253e9ea0c6668125ae1640434eb6d14d095a128537019f387e9e7af1d85a35fe0139d0949bb67e2d1fd3a3b747f7faaa42de02fcc2ceb0df79ccf2e743f8d5099b222f537dd6c146ca7a54bea4e7fc2cdf99f61055817c296c8fab8ff5f242ff31a5853e7d204007e77265e773001de335d520009861246cbbfbdbb4ef1bbf6aaad1e80dadac0415717b633fc04d3fd0d7217a6d47d38b234e832856e2dd1b2c8ab5ba8c23620ccb82236f1ca227cbef4d59cdd58dcdb4ae2e1efae725eff755c7b929190bda4fa9a80a1d752cb5a23174977badceb2ab0a30a64337f46c903e6ae2906f096d6fe475cbd6742d67871fb58bf3c71d598d6f0f6433c1818a3424758acda5d505d815686c0ab43f9c0e783dfa9f918fecc2b831210812c34606b4f3c1ae55853cabe2cc07ea0e97897446d37606ee097c72e3173213774df1539372fadff75e1bef84d9c2d3de2a22d67e416fb23dbddd74a96ec51b4394225",
 			`PLXfZ8ZNN9emRVLapZlvsDpjti3TazobtrY1LWibG5ogf07R5u6xwTGSsBGH10E5naTJLOhj38dFFDeG7giLIvK9QbiF8xSqbXoxvILl09AeXSFfOx7154KdOQdoXMxsghUFi91Efh4uWNl53d7feec7NXh7WrRk68sYUQrfGNdvgxyJlYXBpp7pq5f9Yhhm2TxbNyTyh4dkgvXVJtVfFLwiOWYfO9PAwmfDAgoFyP1vpNcL7G2lCsDW2LuaO1PO0L8a0Z55jpqYrYwzUG3IK4HKnx61xWvawFSzapzGLMrrdxVK56WuToZPOVlLpXjGKYNXlfBXh6T4d1uYUQg9aKfrdIZWCXjVnCXrqDa8vrF0djypIPq24zE0KM0oQZfQJT2Vptu1OPJkes2nIpAUTKxtiLIiunbk8EXaRFBAgGYFFHYm3tHLQUaFQ0K6USoTN3Nr92SjgKUcXVJtSeH854fFpSAoi8je74XPLFHU54GJ0LB3ixHFmD1YQFbBJux7738gI05pxZTwl69KXoat8OfFamLhwNxg8BcA8GXpkN6i5UZW8VfvOQ11nfpd5RykehgYeFyZaewUizPTZkVfI8BT5fdBGQAGXfNT8Xo0OiRxb64rB3Q3YcKiwXjpD1gc14vZXb5EzP6y274yh9RODHPi3rZuVYeGDBd1woFHng2cFeu1ZZ1kBpB30jqqoxDvYzHWvUEpeP3mRyyL51pqYECgOoTEB9nZlb8J31sbAAyY5EXGp6mPuxnhYfR03wIPdkVaDgY9IUdBfKxiIfghTw9Zk9NYZWz1THnqe1GfnBqtHTWiHHuBt0vEJ5QNiMyvcsZbLb6djbbtVFV5sEMzRWf8cJInSEQFgcXPRFaZYow2bJiugFTGvt0ZZKscHqn2SJFNKGRgr3zlcTgF3Y33PVJVTg1uOaZw6y6mbVituSAR5LuDN0zlFuvkOvr63Hys3fE4dONIOxphiDyNG0Nvci5I3bB3E1H1gT8vUDCq`,
@@ -383,13 +417,16 @@ func TestDecryptWithPrivateKeyString(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if decrypted, err := DecryptWithPrivateKeyString(test.inputKey, test.inputEncrypted); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error not expected but got: %s", t.Name(), test.inputKey, test.inputEncrypted, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and error was expected", t.Name(), test.inputKey, test.inputEncrypted)
-		} else if decrypted != test.expectedData {
-			t.Fatalf("%s Failed: [%s] [%s] inputted and [%s] expected, but got: %s", t.Name(), test.inputKey, test.inputEncrypted, test.expectedData, decrypted)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			decrypted, err := DecryptWithPrivateKeyString(test.inputKey, test.inputEncrypted)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedData, decrypted)
+			}
+		})
 	}
 }
 
@@ -413,7 +450,7 @@ func ExampleDecryptWithPrivateKeyString() {
 
 // BenchmarkDecryptWithPrivateKeyString benchmarks the method DecryptWithPrivateKeyString()
 func BenchmarkDecryptWithPrivateKeyString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = DecryptWithPrivateKeyString(
 			"bb66a48a9f6dd7b8fb469a6f08a75c25770591dc509c72129b2aaeca77a5269e",
 			"4fab3e3534e101cef1ec936628894a2c02ca00206b60babbfa6cc"+

--- a/hd_key.go
+++ b/hd_key.go
@@ -153,33 +153,20 @@ func GetAddressStringFromHDKey(hdKey *bip32.ExtendedKey, mainnet bool) (string, 
 // Uses the standard m/0/0 (external) and m/0/1 (internal) paths
 // Reference: https://en.bitcoin.it/wiki/BIP_0032#The_default_wallet_layout
 func GetPublicKeysForPath(hdKey *bip32.ExtendedKey, num uint32) (pubKeys []*ec.PublicKey, err error) {
-	//  m/0/x
-	var childM0x *bip32.ExtendedKey
-	if childM0x, err = GetHDKeyByPath(hdKey, DefaultExternalChain, num); err != nil {
-		return nil, err
-	}
+	// Derive the external (m/0/x) then internal (m/1/x) public keys, in order
+	for _, chain := range []uint32{DefaultExternalChain, DefaultInternalChain} {
+		var child *bip32.ExtendedKey
+		if child, err = GetHDKeyByPath(hdKey, chain, num); err != nil {
+			return nil, err
+		}
 
-	// Get the external pubKey from m/0/x
-	var pubKey *ec.PublicKey
-	if pubKey, err = childM0x.ECPubKey(); err != nil {
-		// Should never error since the previous method ensures a valid hdKey
-		return nil, err
+		// Should never error since GetHDKeyByPath ensures a valid hdKey
+		var pubKey *ec.PublicKey
+		if pubKey, err = child.ECPubKey(); err != nil {
+			return nil, err
+		}
+		pubKeys = append(pubKeys, pubKey)
 	}
-	pubKeys = append(pubKeys, pubKey)
-
-	//  m/1/x
-	var childM1x *bip32.ExtendedKey
-	if childM1x, err = GetHDKeyByPath(hdKey, DefaultInternalChain, num); err != nil {
-		// Should never error since the previous method ensures a valid hdKey
-		return nil, err
-	}
-
-	// Get the internal pubKey from m/1/x
-	if pubKey, err = childM1x.ECPubKey(); err != nil {
-		// Should never error since the previous method ensures a valid hdKey
-		return nil, err
-	}
-	pubKeys = append(pubKeys, pubKey)
 
 	return pubKeys, nil
 }
@@ -221,5 +208,5 @@ func GetExtendedPublicKey(hdKey *bip32.ExtendedKey) (string, error) {
 
 // GetHDKeyFromExtendedPublicKey will get the hd key from an existing extended public key (xPub)
 func GetHDKeyFromExtendedPublicKey(xPublicKey string) (*bip32.ExtendedKey, error) {
-	return bip32.NewKeyFromString(xPublicKey)
+	return GenerateHDKeyFromString(xPublicKey)
 }

--- a/hd_key_test.go
+++ b/hd_key_test.go
@@ -17,28 +17,34 @@ func TestGenerateHDKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		inputSeed     uint8
 		expectedNil   bool
 		expectedError bool
 	}{
-		{0, false, false},
-		{1, true, true},
-		{15, true, true},
-		{65, true, true},
-		{RecommendedSeedLength, false, false},
-		{SecureSeedLength, false, false},
+		{"zero seed defaults to recommended", 0, false, false},
+		{"seed length 1 is invalid", 1, true, true},
+		{"seed length 15 is invalid", 15, true, true},
+		{"seed length 65 is invalid", 65, true, true},
+		{"recommended seed length", RecommendedSeedLength, false, false},
+		{"secure seed length", SecureSeedLength, false, false},
 	}
 
 	for _, test := range tests {
-		if hdKey, err := GenerateHDKey(test.inputSeed); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%d] inputted and error not expected but got: %s", t.Name(), test.inputSeed, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%d] inputted and error was expected", t.Name(), test.inputSeed)
-		} else if hdKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%d] inputted and was nil but not expected", t.Name(), test.inputSeed)
-		} else if hdKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%d] inputted and was NOT nil but expected to be nil", t.Name(), test.inputSeed)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			hdKey, err := GenerateHDKey(test.inputSeed)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, hdKey)
+			} else {
+				assert.NotNil(t, hdKey)
+			}
+		})
 	}
 }
 
@@ -57,14 +63,14 @@ func ExampleGenerateHDKey() {
 
 // BenchmarkGenerateHDKey benchmarks the method GenerateHDKey()
 func BenchmarkGenerateHDKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GenerateHDKey(RecommendedSeedLength)
 	}
 }
 
 // BenchmarkGenerateHDKeySecure benchmarks the method GenerateHDKey()
 func BenchmarkGenerateHDKeySecure(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GenerateHDKey(SecureSeedLength)
 	}
 }
@@ -74,27 +80,30 @@ func TestGenerateHDKeyPair(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		inputSeed     uint8
 		expectedError bool
 	}{
-		{0, false},
-		{1, true},
-		{15, true},
-		{65, true},
-		{RecommendedSeedLength, false},
-		{SecureSeedLength, false},
+		{"zero seed defaults to recommended", 0, false},
+		{"seed length 1 is invalid", 1, true},
+		{"seed length 15 is invalid", 15, true},
+		{"seed length 65 is invalid", 65, true},
+		{"recommended seed length", RecommendedSeedLength, false},
+		{"secure seed length", SecureSeedLength, false},
 	}
 
 	for _, test := range tests {
-		if privateKey, publicKey, err := GenerateHDKeyPair(test.inputSeed); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%d] inputted and error not expected but got: %s", t.Name(), test.inputSeed, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%d] inputted and error was expected", t.Name(), test.inputSeed)
-		} else if err == nil && len(privateKey) == 0 {
-			t.Fatalf("%s Failed: [%d] inputted and private key was empty", t.Name(), test.inputSeed)
-		} else if err == nil && len(publicKey) == 0 {
-			t.Fatalf("%s Failed: [%d] inputted and pubic key was empty", t.Name(), test.inputSeed)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			privateKey, publicKey, err := GenerateHDKeyPair(test.inputSeed)
+			if test.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotEmpty(t, privateKey)
+			assert.NotEmpty(t, publicKey)
+		})
 	}
 }
 
@@ -114,14 +123,14 @@ func ExampleGenerateHDKeyPair() {
 
 // BenchmarkGenerateHDKeyPair benchmarks the method GenerateHDKeyPair()
 func BenchmarkGenerateHDKeyPair(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, _ = GenerateHDKeyPair(RecommendedSeedLength)
 	}
 }
 
 // BenchmarkGenerateHDKeyPairSecure benchmarks the method GenerateHDKeyPair()
 func BenchmarkGenerateHDKeyPairSecure(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, _ = GenerateHDKeyPair(SecureSeedLength)
 	}
 }
@@ -131,50 +140,46 @@ func TestGetPrivateKeyByPath(t *testing.T) {
 	t.Parallel()
 
 	// Generate a valid key
-	validKey, err := GenerateHDKey(RecommendedSeedLength)
-	if err != nil {
-		t.Fatalf("error occurred: %s", err.Error())
-	}
+	validKey := mustHDKey(t)
 
 	tests := []struct {
+		name          string
 		inputHDKey    *bip32.ExtendedKey
 		inputChain    uint32
 		inputNum      uint32
 		expectedNil   bool
 		expectedError bool
 	}{
-		// {nil, 0, 0, true, true},
-		{validKey, 0, 0, false, false},
-		{validKey, 10, 10, false, false},
-		{validKey, 100, 100, false, false},
-		{validKey, 2 ^ 31 + 1, 2 ^ 32 - 1, false, false},
-		{validKey, 1 << 8, 1 << 8, false, false},
-		{validKey, 1 << 9, 1 << 9, false, false},
-		{validKey, 1 << 10, 1 << 10, false, false},
-		{validKey, 1 << 11, 1 << 11, false, false},
-		{validKey, 1 << 12, 1 << 12, false, false},
-		{validKey, 1 << 16, 1 << 16, false, false},
-		{validKey, 1<<32 - 1, 1<<32 - 1, false, false},
+		// {"nil key", nil, 0, 0, true, true},
+		{"chain 0 num 0", validKey, 0, 0, false, false},
+		{"chain 10 num 10", validKey, 10, 10, false, false},
+		{"chain 100 num 100", validKey, 100, 100, false, false},
+		{"chain 2^31+1 num 2^32-1", validKey, 2 ^ 31 + 1, 2 ^ 32 - 1, false, false},
+		{"chain 1<<8 num 1<<8", validKey, 1 << 8, 1 << 8, false, false},
+		{"chain 1<<9 num 1<<9", validKey, 1 << 9, 1 << 9, false, false},
+		{"chain 1<<10 num 1<<10", validKey, 1 << 10, 1 << 10, false, false},
+		{"chain 1<<11 num 1<<11", validKey, 1 << 11, 1 << 11, false, false},
+		{"chain 1<<12 num 1<<12", validKey, 1 << 12, 1 << 12, false, false},
+		{"chain 1<<16 num 1<<16", validKey, 1 << 16, 1 << 16, false, false},
+		{"chain 1<<32-1 num 1<<32-1", validKey, 1<<32 - 1, 1<<32 - 1, false, false},
 	}
 
-	var privateKey *ec.PrivateKey
 	for _, test := range tests {
-		privateKey, err = GetPrivateKeyByPath(test.inputHDKey, test.inputChain, test.inputNum)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and error not expected but got: %s", t.Name(), test.inputHDKey, test.inputChain, test.inputNum, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and error was expected", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
-		if privateKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and was nil but not expected", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
-		if privateKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and was NOT nil but expected to be nil", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
-		if privateKey != nil && len(hex.EncodeToString(privateKey.Serialize())) == 0 {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and should not be empty", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			privateKey, err := GetPrivateKeyByPath(test.inputHDKey, test.inputChain, test.inputNum)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, privateKey)
+			} else {
+				require.NotNil(t, privateKey)
+				assert.NotEmpty(t, hex.EncodeToString(privateKey.Serialize()))
+			}
+		})
 	}
 }
 
@@ -234,7 +239,7 @@ func ExampleGetPrivateKeyByPath() {
 // BenchmarkGetPrivateKeyByPath benchmarks the method GetPrivateKeyByPath()
 func BenchmarkGetPrivateKeyByPath(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetPrivateKeyByPath(hdKey, 0, 1)
 	}
 }
@@ -269,42 +274,42 @@ func TestGetHDKeyByPath(t *testing.T) {
 	*/
 
 	tests := []struct {
+		name          string
 		inputHDKey    *bip32.ExtendedKey
 		inputChain    uint32
 		inputNum      uint32
 		expectedNil   bool
 		expectedError bool
 	}{
-		{validKey, 0, 0, false, false},
-		{validKey, 10, 10, false, false},
-		{validKey, 100, 100, false, false},
-		{validKey, 2 ^ 31 + 1, 2 ^ 32 - 1, false, false},
-		{validKey, 1 << 8, 1 << 8, false, false},
-		{validKey, 1 << 9, 1 << 9, false, false},
-		{validKey, 1 << 10, 1 << 10, false, false},
-		{validKey, 1 << 11, 1 << 11, false, false},
-		{validKey, 1 << 12, 1 << 12, false, false},
-		{validKey, 1 << 16, 1 << 16, false, false},
-		{validKey, 1<<32 - 1, 1<<32 - 1, false, false},
+		{"chain 0 num 0", validKey, 0, 0, false, false},
+		{"chain 10 num 10", validKey, 10, 10, false, false},
+		{"chain 100 num 100", validKey, 100, 100, false, false},
+		{"chain 2^31+1 num 2^32-1", validKey, 2 ^ 31 + 1, 2 ^ 32 - 1, false, false},
+		{"chain 1<<8 num 1<<8", validKey, 1 << 8, 1 << 8, false, false},
+		{"chain 1<<9 num 1<<9", validKey, 1 << 9, 1 << 9, false, false},
+		{"chain 1<<10 num 1<<10", validKey, 1 << 10, 1 << 10, false, false},
+		{"chain 1<<11 num 1<<11", validKey, 1 << 11, 1 << 11, false, false},
+		{"chain 1<<12 num 1<<12", validKey, 1 << 12, 1 << 12, false, false},
+		{"chain 1<<16 num 1<<16", validKey, 1 << 16, 1 << 16, false, false},
+		{"chain 1<<32-1 num 1<<32-1", validKey, 1<<32 - 1, 1<<32 - 1, false, false},
 	}
 
 	for _, test := range tests {
-		hdKey, err := GetHDKeyByPath(test.inputHDKey, test.inputChain, test.inputNum)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and error not expected but got: %s", t.Name(), test.inputHDKey, test.inputChain, test.inputNum, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and error was expected", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
-		if hdKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and was nil but not expected", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
-		if hdKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and was NOT nil but expected to be nil", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
-		if hdKey != nil && len(hdKey.String()) == 0 {
-			t.Fatalf("%s Failed: [%v] [%d] [%d] inputted and should not be empty", t.Name(), test.inputHDKey, test.inputChain, test.inputNum)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			hdKey, err := GetHDKeyByPath(test.inputHDKey, test.inputChain, test.inputNum)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, hdKey)
+			} else {
+				require.NotNil(t, hdKey)
+				assert.NotEmpty(t, hdKey.String())
+			}
+		})
 	}
 }
 
@@ -340,7 +345,7 @@ func ExampleGetHDKeyByPath() {
 // BenchmarkGetHDKeyByPath benchmarks the method GetHDKeyByPath()
 func BenchmarkGetHDKeyByPath(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetHDKeyByPath(hdKey, 0, 1)
 	}
 }
@@ -381,42 +386,42 @@ func TestGetHDKeyChild(t *testing.T) {
 	*/
 
 	tests := []struct {
+		name          string
 		inputHDKey    *bip32.ExtendedKey
 		inputNum      uint32
 		expectedNil   bool
 		expectedError bool
 	}{
-		// {nil, 0, true, true},
-		{validKey, 0, false, false},
-		{validKey, 10, false, false},
-		{validKey, 100, false, false},
-		{validKey, 2 ^ 31 + 1, false, false},
-		{validKey, 1 << 8, false, false},
-		{validKey, 1 << 9, false, false},
-		{validKey, 1 << 10, false, false},
-		{validKey, 1 << 11, false, false},
-		{validKey, 1 << 12, false, false},
-		{validKey, 1 << 16, false, false},
-		{validKey, 1<<32 - 1, false, false},
+		// {"nil key", nil, 0, true, true},
+		{"num 0", validKey, 0, false, false},
+		{"num 10", validKey, 10, false, false},
+		{"num 100", validKey, 100, false, false},
+		{"num 2^31+1", validKey, 2 ^ 31 + 1, false, false},
+		{"num 1<<8", validKey, 1 << 8, false, false},
+		{"num 1<<9", validKey, 1 << 9, false, false},
+		{"num 1<<10", validKey, 1 << 10, false, false},
+		{"num 1<<11", validKey, 1 << 11, false, false},
+		{"num 1<<12", validKey, 1 << 12, false, false},
+		{"num 1<<16", validKey, 1 << 16, false, false},
+		{"num 1<<32-1", validKey, 1<<32 - 1, false, false},
 	}
 
 	for _, test := range tests {
-		hdKey, err := GetHDKeyChild(test.inputHDKey, test.inputNum)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and error not expected but got: %s", t.Name(), test.inputHDKey, test.inputNum, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and error was expected", t.Name(), test.inputHDKey, test.inputNum)
-		}
-		if hdKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and was nil but not expected", t.Name(), test.inputHDKey, test.inputNum)
-		}
-		if hdKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and was NOT nil but expected to be nil", t.Name(), test.inputHDKey, test.inputNum)
-		}
-		if hdKey != nil && len(hdKey.String()) == 0 {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and should not be empty", t.Name(), test.inputHDKey, test.inputNum)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			hdKey, err := GetHDKeyChild(test.inputHDKey, test.inputNum)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, hdKey)
+			} else {
+				require.NotNil(t, hdKey)
+				assert.NotEmpty(t, hdKey.String())
+			}
+		})
 	}
 }
 
@@ -452,7 +457,7 @@ func ExampleGetHDKeyChild() {
 // BenchmarkGetHDKeyChild benchmarks the method GetHDKeyChild()
 func BenchmarkGetHDKeyChild(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetHDKeyChild(hdKey, 0)
 	}
 }
@@ -462,35 +467,35 @@ func TestGenerateHDKeyFromString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedNil   bool
 		expectedError bool
 	}{
-		{"", true, true},
-		{"0", true, true},
-		{"1234567", true, true},
-		{"xprv9s21ZrQH143K3PZSwbEeXEYq74EbnfMngzAiMCZcfjzyRpUvt2vQJnaHRTZjeuEmLXeN6BzYRoFsEckfobxE9XaRzeLGfQoxzPzTRyRb6oE", false, false},
-		{"xprv9s21ZrQH143K3PZSwbEeXEYq74EbnfMngzAiMCZcfjzyRpUv", true, true},
-		{"xprv9s21ZrQH143K3XJueaaswvbJ38UX3FhnXkcA7xF8kqeN62qEu116M1XnqaDpSE7SoKp8NxejVJG9dfpuvBC314VZNdB7W1kQN3Viwgkjr8L", false, false},
+		{"empty string", "", true, true},
+		{"zero", "0", true, true},
+		{"too short numeric", "1234567", true, true},
+		{"valid xprv", "xprv9s21ZrQH143K3PZSwbEeXEYq74EbnfMngzAiMCZcfjzyRpUvt2vQJnaHRTZjeuEmLXeN6BzYRoFsEckfobxE9XaRzeLGfQoxzPzTRyRb6oE", false, false},
+		{"truncated xprv", "xprv9s21ZrQH143K3PZSwbEeXEYq74EbnfMngzAiMCZcfjzyRpUv", true, true},
+		{"valid xprv 2", "xprv9s21ZrQH143K3XJueaaswvbJ38UX3FhnXkcA7xF8kqeN62qEu116M1XnqaDpSE7SoKp8NxejVJG9dfpuvBC314VZNdB7W1kQN3Viwgkjr8L", false, false},
 	}
 
 	for _, test := range tests {
-		hdKey, err := GenerateHDKeyFromString(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		}
-		if hdKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if hdKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if hdKey != nil && hdKey.String() != test.input {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but got: %s", t.Name(), test.input, test.input, hdKey.String())
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			hdKey, err := GenerateHDKeyFromString(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, hdKey)
+			} else {
+				require.NotNil(t, hdKey)
+				assert.Equal(t, test.input, hdKey.String())
+			}
+		})
 	}
 }
 
@@ -509,7 +514,7 @@ func ExampleGenerateHDKeyFromString() {
 // BenchmarkGenerateHDKeyFromString benchmarks the method GenerateHDKeyFromString()
 func BenchmarkGenerateHDKeyFromString(b *testing.B) {
 	xPriv, _, _ := GenerateHDKeyPair(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GenerateHDKeyFromString(xPriv)
 	}
 }
@@ -523,32 +528,32 @@ func TestGetPrivateKeyFromHDKey(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name          string
 		input         *bip32.ExtendedKey
 		expectedKey   string
 		expectedNil   bool
 		expectedError bool
 	}{
-		{new(bip32.ExtendedKey), "", true, true},
-		{validHdKey, "8511f5e1e35ab748e7639aa68666df71857866af13fda1d081d5917948a6cd34", false, false},
+		{"zeroed extended key", new(bip32.ExtendedKey), "", true, true},
+		{"valid hd key", validHdKey, "8511f5e1e35ab748e7639aa68666df71857866af13fda1d081d5917948a6cd34", false, false},
 	}
 
 	for _, test := range tests {
-		privateKey, err := GetPrivateKeyFromHDKey(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		}
-		if privateKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if privateKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if privateKey != nil && hex.EncodeToString(privateKey.Serialize()) != test.expectedKey {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but got: %s", t.Name(), test.input, test.expectedKey, hex.EncodeToString(privateKey.Serialize()))
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			privateKey, err := GetPrivateKeyFromHDKey(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, privateKey)
+			} else {
+				require.NotNil(t, privateKey)
+				assert.Equal(t, test.expectedKey, hex.EncodeToString(privateKey.Serialize()))
+			}
+		})
 	}
 }
 
@@ -583,7 +588,7 @@ func ExampleGetPrivateKeyFromHDKey() {
 // BenchmarkGetPrivateKeyFromHDKey benchmarks the method GetPrivateKeyFromHDKey()
 func BenchmarkGetPrivateKeyFromHDKey(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetPrivateKeyFromHDKey(hdKey)
 	}
 }
@@ -597,23 +602,26 @@ func TestGetPrivateKeyStringFromHDKey(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name          string
 		input         *bip32.ExtendedKey
 		expectedKey   string
 		expectedError bool
 	}{
-		{new(bip32.ExtendedKey), "", true},
-		{validHdKey, "8511f5e1e35ab748e7639aa68666df71857866af13fda1d081d5917948a6cd34", false},
+		{"zeroed extended key", new(bip32.ExtendedKey), "", true},
+		{"valid hd key", validHdKey, "8511f5e1e35ab748e7639aa68666df71857866af13fda1d081d5917948a6cd34", false},
 	}
 
-	var privateKey string
 	for _, test := range tests {
-		if privateKey, err = GetPrivateKeyStringFromHDKey(test.input); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		} else if privateKey != test.expectedKey {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but got: %s", t.Name(), test.input, test.expectedKey, privateKey)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			privateKey, err := GetPrivateKeyStringFromHDKey(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedKey, privateKey)
+		})
 	}
 }
 
@@ -648,7 +656,7 @@ func ExampleGetPrivateKeyStringFromHDKey() {
 // BenchmarkGetPrivateKeyStringFromHDKey benchmarks the method GetPrivateKeyStringFromHDKey()
 func BenchmarkGetPrivateKeyStringFromHDKey(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetPrivateKeyStringFromHDKey(hdKey)
 	}
 }
@@ -662,33 +670,32 @@ func TestGetPublicKeyFromHDKey(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name          string
 		input         *bip32.ExtendedKey
 		expectedKey   string
 		expectedNil   bool
 		expectedError bool
 	}{
-		{new(bip32.ExtendedKey), "", true, true},
-		{validHdKey, "02f2a2942b9d1dba033d36ab0c193e680415f5c8c1ff5d854f805c8c42ed9dd1fd", false, false},
+		{"zeroed extended key", new(bip32.ExtendedKey), "", true, true},
+		{"valid hd key", validHdKey, "02f2a2942b9d1dba033d36ab0c193e680415f5c8c1ff5d854f805c8c42ed9dd1fd", false, false},
 	}
 
-	var publicKey *ec.PublicKey
 	for _, test := range tests {
-		publicKey, err = GetPublicKeyFromHDKey(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		}
-		if publicKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if publicKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if publicKey != nil && hex.EncodeToString(publicKey.Compressed()) != test.expectedKey {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but got: %s", t.Name(), test.input, test.expectedKey, hex.EncodeToString(publicKey.Compressed()))
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			publicKey, err := GetPublicKeyFromHDKey(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, publicKey)
+			} else {
+				require.NotNil(t, publicKey)
+				assert.Equal(t, test.expectedKey, hex.EncodeToString(publicKey.Compressed()))
+			}
+		})
 	}
 }
 
@@ -723,7 +730,7 @@ func ExampleGetPublicKeyFromHDKey() {
 // BenchmarkGetPublicKeyFromHDKey benchmarks the method GetPublicKeyFromHDKey()
 func BenchmarkGetPublicKeyFromHDKey(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetPublicKeyFromHDKey(hdKey)
 	}
 }
@@ -737,35 +744,34 @@ func TestGetAddressFromHDKey(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name            string
 		input           *bip32.ExtendedKey
 		expectedAddress string
 		expectedNil     bool
 		expectedError   bool
 		mainnet         bool
 	}{
-		{new(bip32.ExtendedKey), "", true, true, true},
-		{validHdKey, "13xHrMdZuqa2gpweHf37w8hu6tfv3JrnaW", false, false, true},
-		{validHdKey, "miUF9QiYis1HTwRG1E1Vm3vDxtGczs2oph", false, false, false},
+		{"zeroed extended key mainnet", new(bip32.ExtendedKey), "", true, true, true},
+		{"valid hd key mainnet", validHdKey, "13xHrMdZuqa2gpweHf37w8hu6tfv3JrnaW", false, false, true},
+		{"valid hd key testnet", validHdKey, "miUF9QiYis1HTwRG1E1Vm3vDxtGczs2oph", false, false, false},
 	}
 
-	var address *bscript.Address
 	for _, test := range tests {
-		address, err = GetAddressFromHDKey(test.input, test.mainnet)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		}
-		if address == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if address != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if address != nil && address.AddressString != test.expectedAddress {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but got: %s", t.Name(), test.input, test.expectedAddress, address.AddressString)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			address, err := GetAddressFromHDKey(test.input, test.mainnet)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, address)
+			} else {
+				require.NotNil(t, address)
+				assert.Equal(t, test.expectedAddress, address.AddressString)
+			}
+		})
 	}
 }
 
@@ -800,7 +806,7 @@ func ExampleGetAddressFromHDKey() {
 // BenchmarkGetAddressFromHDKey benchmarks the method GetAddressFromHDKey()
 func BenchmarkGetAddressFromHDKey(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetAddressFromHDKey(hdKey, true)
 	}
 }
@@ -814,25 +820,28 @@ func TestGetAddressStringFromHDKey(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name            string
 		input           *bip32.ExtendedKey
 		expectedAddress string
 		expectedError   bool
 		mainnet         bool
 	}{
-		{new(bip32.ExtendedKey), "", true, true},
-		{validHdKey, "13xHrMdZuqa2gpweHf37w8hu6tfv3JrnaW", false, true},
-		{validHdKey, "miUF9QiYis1HTwRG1E1Vm3vDxtGczs2oph", false, false},
+		{"zeroed extended key mainnet", new(bip32.ExtendedKey), "", true, true},
+		{"valid hd key mainnet", validHdKey, "13xHrMdZuqa2gpweHf37w8hu6tfv3JrnaW", false, true},
+		{"valid hd key testnet", validHdKey, "miUF9QiYis1HTwRG1E1Vm3vDxtGczs2oph", false, false},
 	}
 
-	var address string
 	for _, test := range tests {
-		if address, err = GetAddressStringFromHDKey(test.input, test.mainnet); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		} else if address != test.expectedAddress {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but got: %s", t.Name(), test.input, test.expectedAddress, address)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			address, err := GetAddressStringFromHDKey(test.input, test.mainnet)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedAddress, address)
+		})
 	}
 }
 
@@ -867,7 +876,7 @@ func ExampleGetAddressStringFromHDKey() {
 // BenchmarkGetAddressStringFromHDKey benchmarks the method GetAddressStringFromHDKey()
 func BenchmarkGetAddressStringFromHDKey(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetAddressStringFromHDKey(hdKey, true)
 	}
 }
@@ -881,6 +890,7 @@ func TestGetPublicKeysForPath(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name            string
 		input           *bip32.ExtendedKey
 		inputNum        uint32
 		expectedPubKey1 string
@@ -888,34 +898,30 @@ func TestGetPublicKeysForPath(t *testing.T) {
 		expectedNil     bool
 		expectedError   bool
 	}{
-		{new(bip32.ExtendedKey), 1, "", "", true, true},
-		{validHdKey, 1, "03cc3334f0a6f0fae0420d1442ca0ce64fad0da76d652f2cc3b333e7ed95b97259", "02ceb23902f8dcf6fbff656597ee0343e05c907c6dfcdd8aaf6d033e14e85fd955", false, false},
-		{validHdKey, 2, "020cb908e3b9f3de7c9b40e7bcce63708c5617536d85cf4ab5635e3d3819c02c37", "030007ae60fc6eef98ea17b4f80f9b791e61ea94936e8a9e6ec343eeaa50a875e0", false, false},
-		{validHdKey, 3, "0342593453c476ac6c78eb1b1e586df00b20352e61c42536fe1b33c9fdf3bfbb6f", "03786a41dbf0b099256da26cb0019e10063628f6ce31b96801703f1bb2e1b17724", false, false},
-		{validHdKey, 4, "0366dcdebfc8abfd34bffc181ccb54f1706839a80ad4f0842ae5a43f39fdd35c1e", "03a095db29ae9ee0b22c775118b4444b59db40acdea137fd9ecd9c68dacf50a644", false, false},
+		{"zeroed extended key", new(bip32.ExtendedKey), 1, "", "", true, true},
+		{"valid hd key num 1", validHdKey, 1, "03cc3334f0a6f0fae0420d1442ca0ce64fad0da76d652f2cc3b333e7ed95b97259", "02ceb23902f8dcf6fbff656597ee0343e05c907c6dfcdd8aaf6d033e14e85fd955", false, false},
+		{"valid hd key num 2", validHdKey, 2, "020cb908e3b9f3de7c9b40e7bcce63708c5617536d85cf4ab5635e3d3819c02c37", "030007ae60fc6eef98ea17b4f80f9b791e61ea94936e8a9e6ec343eeaa50a875e0", false, false},
+		{"valid hd key num 3", validHdKey, 3, "0342593453c476ac6c78eb1b1e586df00b20352e61c42536fe1b33c9fdf3bfbb6f", "03786a41dbf0b099256da26cb0019e10063628f6ce31b96801703f1bb2e1b17724", false, false},
+		{"valid hd key num 4", validHdKey, 4, "0366dcdebfc8abfd34bffc181ccb54f1706839a80ad4f0842ae5a43f39fdd35c1e", "03a095db29ae9ee0b22c775118b4444b59db40acdea137fd9ecd9c68dacf50a644", false, false},
 	}
 
-	var pubKeys []*ec.PublicKey
 	for _, test := range tests {
-		pubKeys, err = GetPublicKeysForPath(test.input, test.inputNum)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and error not expected but got: %s", t.Name(), test.input, test.inputNum, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and error was expected", t.Name(), test.input, test.inputNum)
-		}
-		if pubKeys == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and was nil but not expected", t.Name(), test.input, test.inputNum)
-		}
-		if pubKeys != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and was NOT nil but expected to be nil", t.Name(), test.input, test.inputNum)
-		}
-		if pubKeys != nil && hex.EncodeToString(pubKeys[0].Compressed()) != test.expectedPubKey1 {
-			t.Fatalf("%s Failed: [%v] [%d] inputted key 1 [%s] expected but got: %s", t.Name(), test.input, test.inputNum, test.expectedPubKey1, hex.EncodeToString(pubKeys[0].Compressed()))
-		}
-		if pubKeys != nil && hex.EncodeToString(pubKeys[1].Compressed()) != test.expectedPubKey2 {
-			t.Fatalf("%s Failed: [%v] [%d] inputted key 2 [%s] expected but got: %s", t.Name(), test.input, test.inputNum, test.expectedPubKey2, hex.EncodeToString(pubKeys[1].Compressed()))
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			pubKeys, err := GetPublicKeysForPath(test.input, test.inputNum)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, pubKeys)
+			} else {
+				require.Len(t, pubKeys, 2)
+				assert.Equal(t, test.expectedPubKey1, hex.EncodeToString(pubKeys[0].Compressed()))
+				assert.Equal(t, test.expectedPubKey2, hex.EncodeToString(pubKeys[1].Compressed()))
+			}
+		})
 	}
 }
 
@@ -951,7 +957,7 @@ func ExampleGetPublicKeysForPath() {
 // BenchmarkGetPublicKeysForPath benchmarks the method GetPublicKeysForPath()
 func BenchmarkGetPublicKeysForPath(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetPublicKeysForPath(hdKey, 5)
 	}
 }
@@ -965,6 +971,7 @@ func TestGetAddressesForPath(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name             string
 		input            *bip32.ExtendedKey
 		inputNum         uint32
 		expectedAddress1 string
@@ -973,34 +980,30 @@ func TestGetAddressesForPath(t *testing.T) {
 		expectedError    bool
 		mainnet          bool
 	}{
-		{new(bip32.ExtendedKey), 1, "", "", true, true, true},
-		{validHdKey, 1, "1KMxfSfRCkC1jrBAuYaLde4XBzdsWApbdH", "174DL9ZbBWx568ssAg8w2YwW6FTTBwXGEu", false, false, true},
-		{validHdKey, 2, "18s3peTU7fMSwgui54avpnqm1126pRVccw", "1KgZZ3NsJDw3v1GPHBj8ASnxutA1kFxo2i", false, false, true},
-		{validHdKey, 1, "mysuxVkQ1mdGWxend7YiTZGr3zEaTcMjrz", "mmaAdCeZzYPKsFMUtF7JrU9pxF4AAgMHK5", false, false, false},
-		{new(bip32.ExtendedKey), 1, "", "", true, true, false},
+		{"zeroed extended key mainnet", new(bip32.ExtendedKey), 1, "", "", true, true, true},
+		{"valid hd key num 1 mainnet", validHdKey, 1, "1KMxfSfRCkC1jrBAuYaLde4XBzdsWApbdH", "174DL9ZbBWx568ssAg8w2YwW6FTTBwXGEu", false, false, true},
+		{"valid hd key num 2 mainnet", validHdKey, 2, "18s3peTU7fMSwgui54avpnqm1126pRVccw", "1KgZZ3NsJDw3v1GPHBj8ASnxutA1kFxo2i", false, false, true},
+		{"valid hd key num 1 testnet", validHdKey, 1, "mysuxVkQ1mdGWxend7YiTZGr3zEaTcMjrz", "mmaAdCeZzYPKsFMUtF7JrU9pxF4AAgMHK5", false, false, false},
+		{"zeroed extended key testnet", new(bip32.ExtendedKey), 1, "", "", true, true, false},
 	}
 
-	var addresses []string
 	for _, test := range tests {
-		addresses, err = GetAddressesForPath(test.input, test.inputNum, test.mainnet)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and error not expected but got: %s", t.Name(), test.input, test.inputNum, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and error was expected", t.Name(), test.input, test.inputNum)
-		}
-		if addresses == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and was nil but not expected", t.Name(), test.input, test.inputNum)
-		}
-		if addresses != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%d] inputted and was NOT nil but expected to be nil", t.Name(), test.input, test.inputNum)
-		}
-		if addresses != nil && addresses[0] != test.expectedAddress1 {
-			t.Fatalf("%s Failed: [%v] [%d] inputted address 1 [%s] expected but got: %s", t.Name(), test.input, test.inputNum, test.expectedAddress1, addresses[0])
-		}
-		if addresses != nil && addresses[1] != test.expectedAddress2 {
-			t.Fatalf("%s Failed: [%v] [%d] inputted address 2 [%s] expected but got: %s", t.Name(), test.input, test.inputNum, test.expectedAddress2, addresses[1])
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			addresses, err := GetAddressesForPath(test.input, test.inputNum, test.mainnet)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, addresses)
+			} else {
+				require.Len(t, addresses, 2)
+				assert.Equal(t, test.expectedAddress1, addresses[0])
+				assert.Equal(t, test.expectedAddress2, addresses[1])
+			}
+		})
 	}
 }
 
@@ -1035,7 +1038,7 @@ func ExampleGetAddressesForPath() {
 // BenchmarkGetAddressesForPath benchmarks the method GetAddressesForPath()
 func BenchmarkGetAddressesForPath(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetAddressesForPath(hdKey, 5, true)
 	}
 }
@@ -1049,23 +1052,26 @@ func TestGetExtendedPublicKey(t *testing.T) {
 	assert.NotNil(t, validHdKey)
 
 	tests := []struct {
+		name          string
 		input         *bip32.ExtendedKey
 		expectedKey   string
 		expectedError bool
 	}{
-		{validHdKey, "xpub661MyMwAqRbcGjhmJnvR198z2x9XnnDhz2yBtLuTdXQ2VBQj8eJ9RnxmXxKnRPhYy6nLsmabmUfVkbajvP7aZASrrnoZkzmwgyjiNskiefG", false},
-		{new(bip32.ExtendedKey), "zeroed extended key", false},
+		{"valid hd key", validHdKey, "xpub661MyMwAqRbcGjhmJnvR198z2x9XnnDhz2yBtLuTdXQ2VBQj8eJ9RnxmXxKnRPhYy6nLsmabmUfVkbajvP7aZASrrnoZkzmwgyjiNskiefG", false},
+		{"zeroed extended key", new(bip32.ExtendedKey), "zeroed extended key", false},
 	}
 
-	var xPub string
 	for _, test := range tests {
-		if xPub, err = GetExtendedPublicKey(test.input); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.input)
-		} else if xPub != test.expectedKey {
-			t.Fatalf("%s Failed: [%v] inputted and [%s] expected but got: %s", t.Name(), test.input, test.expectedKey, xPub)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			xPub, err := GetExtendedPublicKey(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedKey, xPub)
+		})
 	}
 }
 
@@ -1100,7 +1106,7 @@ func ExampleGetExtendedPublicKey() {
 // BenchmarkGetExtendedPublicKey benchmarks the method GetExtendedPublicKey()
 func BenchmarkGetExtendedPublicKey(b *testing.B) {
 	hdKey, _ := GenerateHDKey(SecureSeedLength)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetExtendedPublicKey(hdKey)
 	}
 }
@@ -1110,30 +1116,35 @@ func TestGetHDKeyFromExtendedPublicKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedKey   string
 		expectedError bool
 		expectedNil   bool
 	}{
 		{
+			"valid xpub",
 			"xpub661MyMwAqRbcGjhmJnvR198z2x9XnnDhz2yBtLuTdXQ2VBQj8eJ9RnxmXxKnRPhYy6nLsmabmUfVkbajvP7aZASrrnoZkzmwgyjiNskiefG",
 			"xpub661MyMwAqRbcGjhmJnvR198z2x9XnnDhz2yBtLuTdXQ2VBQj8eJ9RnxmXxKnRPhYy6nLsmabmUfVkbajvP7aZASrrnoZkzmwgyjiNskiefG",
 			false,
 			false,
 		},
 		{
+			"valid xpub 2",
 			"xpub661MyMwAqRbcH3WGvLjupmr43L1GVH3MP2WQWvdreDraBeFJy64Xxv4LLX9ZVWWz3ZjZkMuZtSsc9qH9JZR74bR4PWkmtEvP423r6DJR8kA",
 			"xpub661MyMwAqRbcH3WGvLjupmr43L1GVH3MP2WQWvdreDraBeFJy64Xxv4LLX9ZVWWz3ZjZkMuZtSsc9qH9JZR74bR4PWkmtEvP423r6DJR8kA",
 			false,
 			false,
 		},
 		{
+			"empty string",
 			"",
 			"",
 			true,
 			true,
 		},
 		{
+			"zero",
 			"0",
 			"",
 			true,
@@ -1142,22 +1153,21 @@ func TestGetHDKeyFromExtendedPublicKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		xPub, err := GetHDKeyFromExtendedPublicKey(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		}
-		if xPub == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if xPub != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if xPub != nil && xPub.String() != test.expectedKey {
-			t.Fatalf("%s Failed: [%s] inputted and [%s] expected but got: %s", t.Name(), test.input, test.expectedKey, xPub)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			xPub, err := GetHDKeyFromExtendedPublicKey(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, xPub)
+			} else {
+				require.NotNil(t, xPub)
+				assert.Equal(t, test.expectedKey, xPub.String())
+			}
+		})
 	}
 }
 
@@ -1180,7 +1190,7 @@ func ExampleGetHDKeyFromExtendedPublicKey() {
 // BenchmarkGetHDKeyFromExtendedPublicKey benchmarks the method GetHDKeyFromExtendedPublicKey()
 func BenchmarkGetHDKeyFromExtendedPublicKey(b *testing.B) {
 	xPub := "xpub661MyMwAqRbcH3WGvLjupmr43L1GVH3MP2WQWvdreDraBeFJy64Xxv4LLX9ZVWWz3ZjZkMuZtSsc9qH9JZR74bR4PWkmtEvP423r6DJR8kA"
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetHDKeyFromExtendedPublicKey(xPub)
 	}
 }

--- a/misc_functions_test.go
+++ b/misc_functions_test.go
@@ -20,6 +20,7 @@ func TestEncryptDecryptExtended(t *testing.T) {
 	testData := "Test data to encrypt"
 
 	t.Run("encrypt and decrypt with private key object", func(t *testing.T) {
+		t.Parallel()
 		encrypted, err := EncryptWithPrivateKey(privateKey, testData)
 		require.NoError(t, err)
 		assert.NotEmpty(t, encrypted)
@@ -30,6 +31,7 @@ func TestEncryptDecryptExtended(t *testing.T) {
 	})
 
 	t.Run("encrypt and decrypt with private key string", func(t *testing.T) {
+		t.Parallel()
 		encrypted, err := EncryptWithPrivateKeyString(privateKeyString, testData)
 		require.NoError(t, err)
 		assert.NotEmpty(t, encrypted)
@@ -40,24 +42,28 @@ func TestEncryptDecryptExtended(t *testing.T) {
 	})
 
 	t.Run("encrypt with empty data", func(t *testing.T) {
+		t.Parallel()
 		encrypted, err := EncryptWithPrivateKey(privateKey, "")
 		require.NoError(t, err)
 		assert.NotEmpty(t, encrypted)
 	})
 
 	t.Run("decrypt with invalid hex", func(t *testing.T) {
+		t.Parallel()
 		decrypted, err := DecryptWithPrivateKey(privateKey, "not-hex")
 		require.Error(t, err)
 		assert.Empty(t, decrypted)
 	})
 
 	t.Run("encrypt with invalid private key string", func(t *testing.T) {
+		t.Parallel()
 		encrypted, err := EncryptWithPrivateKeyString("invalid", testData)
 		require.Error(t, err)
 		assert.Empty(t, encrypted)
 	})
 
 	t.Run("decrypt with invalid private key string", func(t *testing.T) {
+		t.Parallel()
 		decrypted, err := DecryptWithPrivateKeyString("invalid", "abcd1234")
 		require.Error(t, err)
 		assert.Empty(t, decrypted)
@@ -77,6 +83,7 @@ func TestEncryptSharedExtended(t *testing.T) {
 	testData := []byte("Shared secret data")
 
 	t.Run("encrypt and decrypt shared data", func(t *testing.T) {
+		t.Parallel()
 		sharedPrivKey, sharedPubKey, encrypted, err := EncryptShared(user1Key, user2Key.PubKey(), testData)
 		require.NoError(t, err)
 		assert.NotNil(t, sharedPrivKey)
@@ -85,6 +92,7 @@ func TestEncryptSharedExtended(t *testing.T) {
 	})
 
 	t.Run("encrypt shared string", func(t *testing.T) {
+		t.Parallel()
 		sharedPrivKey, sharedPubKey, encrypted, err := EncryptSharedString(user1Key, user2Key.PubKey(), string(testData))
 		require.NoError(t, err)
 		assert.NotNil(t, sharedPrivKey)
@@ -99,6 +107,7 @@ func TestCreateKeysExtended(t *testing.T) {
 	t.Parallel()
 
 	t.Run("create private key string", func(t *testing.T) {
+		t.Parallel()
 		keyString, err := CreatePrivateKeyString()
 		require.NoError(t, err)
 		assert.NotEmpty(t, keyString)
@@ -106,6 +115,7 @@ func TestCreateKeysExtended(t *testing.T) {
 	})
 
 	t.Run("create wif", func(t *testing.T) {
+		t.Parallel()
 		wifObj, err := CreateWif()
 		require.NoError(t, err)
 		assert.NotNil(t, wifObj)
@@ -113,12 +123,14 @@ func TestCreateKeysExtended(t *testing.T) {
 	})
 
 	t.Run("create wif string", func(t *testing.T) {
+		t.Parallel()
 		wifString, err := CreateWifString()
 		require.NoError(t, err)
 		assert.NotEmpty(t, wifString)
 	})
 
 	t.Run("private key to wif and back", func(t *testing.T) {
+		t.Parallel()
 		keyString, err := CreatePrivateKeyString()
 		require.NoError(t, err)
 
@@ -132,6 +144,7 @@ func TestCreateKeysExtended(t *testing.T) {
 	})
 
 	t.Run("private key to wif - empty key error", func(t *testing.T) {
+		t.Parallel()
 		wif, err := PrivateKeyToWif("")
 		require.Error(t, err)
 		assert.Nil(t, wif)
@@ -139,6 +152,7 @@ func TestCreateKeysExtended(t *testing.T) {
 	})
 
 	t.Run("private key to wif string - invalid hex", func(t *testing.T) {
+		t.Parallel()
 		wifString, err := PrivateKeyToWifString("not-hex")
 		require.Error(t, err)
 		assert.Empty(t, wifString)
@@ -152,30 +166,35 @@ func TestGetAddressesExtended(t *testing.T) {
 	privateKey := testPrivateKeyHex
 
 	t.Run("get address from private key string - mainnet compressed", func(t *testing.T) {
+		t.Parallel()
 		address, err := GetAddressFromPrivateKeyString(privateKey, true, true)
 		require.NoError(t, err)
 		assert.NotEmpty(t, address)
 	})
 
 	t.Run("get address from private key string - mainnet uncompressed", func(t *testing.T) {
+		t.Parallel()
 		address, err := GetAddressFromPrivateKeyString(privateKey, false, true)
 		require.NoError(t, err)
 		assert.NotEmpty(t, address)
 	})
 
 	t.Run("get address from private key string - testnet", func(t *testing.T) {
+		t.Parallel()
 		address, err := GetAddressFromPrivateKeyString(privateKey, true, false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, address)
 	})
 
 	t.Run("get address from private key string - invalid hex", func(t *testing.T) {
+		t.Parallel()
 		address, err := GetAddressFromPrivateKeyString("not-hex", true, true)
 		require.Error(t, err)
 		assert.Empty(t, address)
 	})
 
 	t.Run("get address from script - valid", func(t *testing.T) {
+		t.Parallel()
 		script := "76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2996388ac"
 		address, err := GetAddressFromScript(script)
 		require.NoError(t, err)
@@ -183,6 +202,7 @@ func TestGetAddressesExtended(t *testing.T) {
 	})
 
 	t.Run("get address from script - empty script", func(t *testing.T) {
+		t.Parallel()
 		address, err := GetAddressFromScript("")
 		require.Error(t, err)
 		assert.Empty(t, address)
@@ -190,12 +210,14 @@ func TestGetAddressesExtended(t *testing.T) {
 	})
 
 	t.Run("get address from script - invalid hex", func(t *testing.T) {
+		t.Parallel()
 		address, err := GetAddressFromScript("not-hex")
 		require.Error(t, err)
 		assert.Empty(t, address)
 	})
 
 	t.Run("get address from pubkey string - compressed", func(t *testing.T) {
+		t.Parallel()
 		pk, err := PrivateKeyFromString(privateKey)
 		require.NoError(t, err)
 
@@ -207,6 +229,7 @@ func TestGetAddressesExtended(t *testing.T) {
 	})
 
 	t.Run("get address from pubkey string - invalid", func(t *testing.T) {
+		t.Parallel()
 		address, err := GetAddressFromPubKeyString("invalid", true, true)
 		require.Error(t, err)
 		assert.Nil(t, address)
@@ -218,20 +241,21 @@ func TestHDKeyExtended(t *testing.T) {
 	t.Parallel()
 
 	t.Run("generate HD key with custom seed length", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 		assert.NotNil(t, key)
 	})
 
 	t.Run("generate HD key with secure seed length", func(t *testing.T) {
+		t.Parallel()
 		key, err := GenerateHDKey(SecureSeedLength)
 		require.NoError(t, err)
 		assert.NotNil(t, key)
 	})
 
 	t.Run("get extended public key from HD key", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 
 		xPub, err := GetExtendedPublicKey(key)
 		require.NoError(t, err)
@@ -240,8 +264,8 @@ func TestHDKeyExtended(t *testing.T) {
 	})
 
 	t.Run("get private key by path", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 
 		privKey, err := GetPrivateKeyByPath(key, 0, 0)
 		require.NoError(t, err)
@@ -249,8 +273,8 @@ func TestHDKeyExtended(t *testing.T) {
 	})
 
 	t.Run("get public keys for path", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 
 		pubKeys, err := GetPublicKeysForPath(key, 0)
 		require.NoError(t, err)
@@ -258,8 +282,8 @@ func TestHDKeyExtended(t *testing.T) {
 	})
 
 	t.Run("get addresses for path - mainnet", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 
 		addresses, err := GetAddressesForPath(key, 0, true)
 		require.NoError(t, err)
@@ -267,8 +291,8 @@ func TestHDKeyExtended(t *testing.T) {
 	})
 
 	t.Run("get addresses for path - testnet", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 
 		addresses, err := GetAddressesForPath(key, 0, false)
 		require.NoError(t, err)
@@ -276,8 +300,8 @@ func TestHDKeyExtended(t *testing.T) {
 	})
 
 	t.Run("get address string from HD key", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 
 		address, err := GetAddressStringFromHDKey(key, true)
 		require.NoError(t, err)
@@ -285,8 +309,8 @@ func TestHDKeyExtended(t *testing.T) {
 	})
 
 	t.Run("get private key string from HD key", func(t *testing.T) {
-		key, err := GenerateHDKey(RecommendedSeedLength)
-		require.NoError(t, err)
+		t.Parallel()
+		key := mustHDKey(t)
 
 		privKeyString, err := GetPrivateKeyStringFromHDKey(key)
 		require.NoError(t, err)
@@ -302,6 +326,7 @@ func TestPubKeyFunctions(t *testing.T) {
 	privateKey := testPrivateKeyHex
 
 	t.Run("pubkey from private key string - compressed", func(t *testing.T) {
+		t.Parallel()
 		pubKey, err := PubKeyFromPrivateKeyString(privateKey, true)
 		require.NoError(t, err)
 		assert.NotEmpty(t, pubKey)
@@ -309,6 +334,7 @@ func TestPubKeyFunctions(t *testing.T) {
 	})
 
 	t.Run("pubkey from private key string - uncompressed", func(t *testing.T) {
+		t.Parallel()
 		pubKey, err := PubKeyFromPrivateKeyString(privateKey, false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, pubKey)
@@ -316,12 +342,14 @@ func TestPubKeyFunctions(t *testing.T) {
 	})
 
 	t.Run("pubkey from string - invalid", func(t *testing.T) {
+		t.Parallel()
 		pk, err := PubKeyFromString("invalid")
 		require.Error(t, err)
 		assert.Nil(t, pk)
 	})
 
 	t.Run("pubkey from string - empty", func(t *testing.T) {
+		t.Parallel()
 		pk, err := PubKeyFromString("")
 		require.Error(t, err)
 		assert.Nil(t, pk)

--- a/private_key.go
+++ b/private_key.go
@@ -17,16 +17,27 @@ func GenerateSharedKeyPair(privateKey *ec.PrivateKey,
 	)
 }
 
-// PrivateKeyFromString turns a private key (hex encoded string) into an ec.PrivateKey
-func PrivateKeyFromString(privateKey string) (*ec.PrivateKey, error) {
-	if len(privateKey) == 0 {
-		return nil, ErrPrivateKeyMissing
+// privateKeyFromHex decodes a hex-encoded private key string into its
+// ec.PrivateKey and matching ec.PublicKey. It returns ErrPrivateKeyMissing for
+// an empty string and the hex decode error for malformed input.
+func privateKeyFromHex(privateKey string) (*ec.PrivateKey, *ec.PublicKey, error) {
+	if privateKey == "" {
+		return nil, nil, ErrPrivateKeyMissing
 	}
 	privateKeyBytes, err := hex.DecodeString(privateKey)
 	if err != nil {
+		return nil, nil, err
+	}
+	rawKey, publicKey := ec.PrivateKeyFromBytes(privateKeyBytes)
+	return rawKey, publicKey, nil
+}
+
+// PrivateKeyFromString turns a private key (hex encoded string) into an ec.PrivateKey
+func PrivateKeyFromString(privateKey string) (*ec.PrivateKey, error) {
+	rawKey, _, err := privateKeyFromHex(privateKey)
+	if err != nil {
 		return nil, err
 	}
-	rawKey, _ := ec.PrivateKeyFromBytes(privateKeyBytes)
 	return rawKey, nil
 }
 
@@ -86,20 +97,7 @@ func CreateWifStringWithCompression(compress bool) (string, error) {
 // PrivateAndPublicKeys will return both the private and public key in one method
 // Expects a hex encoded privateKey
 func PrivateAndPublicKeys(privateKey string) (*ec.PrivateKey, *ec.PublicKey, error) {
-	// No key?
-	if len(privateKey) == 0 {
-		return nil, nil, ErrPrivateKeyMissing
-	}
-
-	// Decode the private key into bytes
-	privateKeyBytes, err := hex.DecodeString(privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Get the public and private key from the bytes
-	rawKey, publicKey := ec.PrivateKeyFromBytes(privateKeyBytes)
-	return rawKey, publicKey, nil
+	return privateKeyFromHex(privateKey)
 }
 
 // PrivateKeyToWif will convert a private key to an uncompressed mainnet WIF (*WIF).
@@ -112,19 +110,11 @@ func PrivateKeyToWif(privateKey string) (*WIF, error) {
 // PrivateKeyToWifWithCompression will convert a hex private key to a mainnet WIF
 // (*WIF) using the chosen public-key compression.
 func PrivateKeyToWifWithCompression(privateKey string, compress bool) (*WIF, error) {
-	// Missing private key
-	if len(privateKey) == 0 {
-		return nil, ErrPrivateKeyMissing
-	}
-
-	// Decode the private key
-	decodedKey, err := hex.DecodeString(privateKey)
+	// Decode the private key (returns ErrPrivateKeyMissing for an empty string)
+	rawKey, _, err := privateKeyFromHex(privateKey)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the private key from bytes
-	rawKey, _ := ec.PrivateKeyFromBytes(decodedKey)
 
 	// Create a new WIF (error never gets hit since (net) is set correctly)
 	return NewWIF(rawKey, &chaincfg.MainNet, compress)
@@ -151,7 +141,7 @@ func PrivateKeyToWifStringWithCompression(privateKey string, compress bool) (str
 // WifToPrivateKey will convert a WIF to a private key (*ec.PrivateKey)
 func WifToPrivateKey(wifKey string) (*ec.PrivateKey, error) {
 	// Missing wif?
-	if len(wifKey) == 0 {
+	if wifKey == "" {
 		return nil, ErrWifMissing
 	}
 
@@ -180,7 +170,7 @@ func WifToPrivateKeyString(wifKey string) (string, error) {
 // WifFromString will convert a WIF (string) to a WIF (*WIF)
 func WifFromString(wifKey string) (*WIF, error) {
 	// Missing wif?
-	if len(wifKey) == 0 {
+	if wifKey == "" {
 		return nil, ErrWifMissing
 	}
 

--- a/private_key_fuzz_test.go
+++ b/private_key_fuzz_test.go
@@ -30,7 +30,7 @@ func FuzzPrivateKeyFromString(f *testing.F) {
 // WIF strings to ensure proper error handling and no panics
 func FuzzWifToPrivateKey(f *testing.F) {
 	// Seed corpus with valid and invalid WIF strings
-	f.Add("5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei")
+	f.Add(testUncompressedWIF)
 	f.Add("5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU")
 	f.Add("5KgHn2qiftW5LQgCYFtkbrLYB1FuvisDtacax8NCvumw3UTKdcP")
 	f.Add(testWIF)
@@ -52,7 +52,7 @@ func FuzzWifToPrivateKey(f *testing.F) {
 // various WIF strings to ensure robust error handling
 func FuzzWifToPrivateKeyString(f *testing.F) {
 	// Seed corpus with valid and invalid WIF strings
-	f.Add("5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei")
+	f.Add(testUncompressedWIF)
 	f.Add("5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU")
 	f.Add("5KgHn2qiftW5LQgCYFtkbrLYB1FuvisDtacax8NCvumw3UTKdcP")
 	f.Add(testWIF)

--- a/private_key_test.go
+++ b/private_key_test.go
@@ -32,7 +32,7 @@ func ExampleCreatePrivateKey() {
 
 // BenchmarkCreatePrivateKey benchmarks the method CreatePrivateKey()
 func BenchmarkCreatePrivateKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreatePrivateKey()
 	}
 }
@@ -58,7 +58,7 @@ func ExampleCreatePrivateKeyString() {
 
 // BenchmarkCreatePrivateKeyString benchmarks the method CreatePrivateKeyString()
 func BenchmarkCreatePrivateKeyString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreatePrivateKeyString()
 	}
 }
@@ -68,37 +68,38 @@ func TestPrivateKeyFromString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedKey   string
 		expectedNil   bool
 		expectedError bool
 	}{
-		{testPrivateKeyHex, testPrivateKeyHex, false, false},
-		{"E83385AF76B2B1997326B567461FB73DD9C27EAB9E1E86D26779F4650C5F2B75", "e83385af76b2b1997326b567461fb73dd9c27eab9e1e86d26779f4650c5f2b75", false, false},
-		{"E83385AF76B2B1997326B567461FB73DD9C27EAB9E1E86D26779F4650C5F", "0000e83385af76b2b1997326b567461fb73dd9c27eab9e1e86d26779f4650c5f", false, false},
-		{"E83385AF76B2B1997326B567461FB73DD9C27EAB9E1E86D26779F", "", true, true},
-		{"1234567", "", true, true},
-		{"0", "", true, true},
-		{"", "", true, true},
+		{"valid key", testPrivateKeyHex, testPrivateKeyHex, false, false},
+		{"uppercase hex", "E83385AF76B2B1997326B567461FB73DD9C27EAB9E1E86D26779F4650C5F2B75", "e83385af76b2b1997326b567461fb73dd9c27eab9e1e86d26779f4650c5f2b75", false, false},
+		{"short key left-padded", "E83385AF76B2B1997326B567461FB73DD9C27EAB9E1E86D26779F4650C5F", "0000e83385af76b2b1997326b567461fb73dd9c27eab9e1e86d26779f4650c5f", false, false},
+		{"odd length hex", "E83385AF76B2B1997326B567461FB73DD9C27EAB9E1E86D26779F", "", true, true},
+		{"too short odd hex", "1234567", "", true, true},
+		{caseSingleZero, "0", "", true, true},
+		{caseEmpty, "", "", true, true},
 	}
 
 	for _, test := range tests {
-		rawKey, err := PrivateKeyFromString(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		}
-		if rawKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if rawKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if rawKey != nil && hex.EncodeToString(rawKey.Serialize()) != test.expectedKey {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but failed comparison of keys, got: %s", t.Name(), test.input, test.expectedKey, hex.EncodeToString(rawKey.Serialize()))
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			rawKey, err := PrivateKeyFromString(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, rawKey)
+			} else {
+				require.NotNil(t, rawKey)
+				assert.Equal(t, test.expectedKey, hex.EncodeToString(rawKey.Serialize()))
+			}
+		})
 	}
 }
 
@@ -116,7 +117,7 @@ func ExamplePrivateKeyFromString() {
 // BenchmarkPrivateKeyFromString benchmarks the method PrivateKeyFromString()
 func BenchmarkPrivateKeyFromString(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = PrivateKeyFromString(key)
 	}
 }
@@ -126,36 +127,39 @@ func TestPrivateAndPublicKeys(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name               string
 		input              string
 		expectedPrivateKey string
 		expectedNil        bool
 		expectedError      bool
 	}{
-		{"", "", true, true},
-		{"0", "", true, true},
-		{"00000", "", true, true},
-		{"0-0-0-0-0", "", true, true},
-		{"z4035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8abz", "", true, true},
-		{testPrivateKeyHex, testPrivateKeyHex, false, false},
+		{caseEmpty, "", "", true, true},
+		{caseSingleZero, "0", "", true, true},
+		{"short zeros", "00000", "", true, true},
+		{"dashes", "0-0-0-0-0", "", true, true},
+		{"invalid hex chars", "z4035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8abz", "", true, true},
+		{"valid key", testPrivateKeyHex, testPrivateKeyHex, false, false},
 	}
 
 	for _, test := range tests {
-		privateKey, publicKey, err := PrivateAndPublicKeys(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		}
-		if (privateKey == nil || publicKey == nil) && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if (privateKey != nil || publicKey != nil) && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if privateKey != nil && hex.EncodeToString(privateKey.Serialize()) != test.expectedPrivateKey {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but failed comparison of keys, got: %s", t.Name(), test.input, test.expectedPrivateKey, hex.EncodeToString(privateKey.Serialize()))
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			privateKey, publicKey, err := PrivateAndPublicKeys(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, privateKey)
+				assert.Nil(t, publicKey)
+			} else {
+				require.NotNil(t, privateKey)
+				require.NotNil(t, publicKey)
+				assert.Equal(t, test.expectedPrivateKey, hex.EncodeToString(privateKey.Serialize()))
+			}
+		})
 	}
 }
 
@@ -174,7 +178,7 @@ func ExamplePrivateAndPublicKeys() {
 // BenchmarkPrivateAndPublicKeys benchmarks the method PrivateAndPublicKeys()
 func BenchmarkPrivateAndPublicKeys(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, _ = PrivateAndPublicKeys(key)
 	}
 }
@@ -184,36 +188,37 @@ func TestPrivateKeyToWif(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedWif   string
 		expectedNil   bool
 		expectedError bool
 	}{
-		{"", "", true, true},
-		{"0", "", true, true},
-		{"000000", "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", false, false},
-		{"6D792070726976617465206B6579", "5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", false, false},
-		{"54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true, true},
-		{testPrivateKeyHex, "5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei", false, false},
+		{caseEmpty, "", "", true, true},
+		{caseSingleZero, "0", "", true, true},
+		{"zeros key", "000000", "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", false, false},
+		{"ascii key bytes", "6D792070726976617465206B6579", "5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", false, false},
+		{"invalid hex chars", "54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true, true},
+		{"valid key", testPrivateKeyHex, testUncompressedWIF, false, false},
 	}
 
 	for _, test := range tests {
-		privateWif, err := PrivateKeyToWif(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		}
-		if privateWif == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if privateWif != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if privateWif != nil && privateWif.String() != test.expectedWif {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but failed comparison of keys, got: %s", t.Name(), test.input, test.expectedWif, privateWif.String())
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			privateWif, err := PrivateKeyToWif(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, privateWif)
+			} else {
+				require.NotNil(t, privateWif)
+				assert.Equal(t, test.expectedWif, privateWif.String())
+			}
+		})
 	}
 }
 
@@ -232,7 +237,7 @@ func ExamplePrivateKeyToWif() {
 // BenchmarkPrivateKeyToWif benchmarks the method PrivateKeyToWif()
 func BenchmarkPrivateKeyToWif(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = PrivateKeyToWif(key)
 	}
 }
@@ -242,26 +247,31 @@ func TestPrivateKeyToWifString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedWif   string
 		expectedError bool
 	}{
-		{"", "", true},
-		{"0", "", true},
-		{"000000", "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", false},
-		{"6D792070726976617465206B6579", "5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", false},
-		{"54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true},
-		{testPrivateKeyHex, "5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei", false},
+		{caseEmpty, "", "", true},
+		{caseSingleZero, "0", "", true},
+		{"zeros key", "000000", "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", false},
+		{"ascii key bytes", "6D792070726976617465206B6579", "5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", false},
+		{"invalid hex chars", "54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true},
+		{"valid key", testPrivateKeyHex, testUncompressedWIF, false},
 	}
 
 	for _, test := range tests {
-		if privateWif, err := PrivateKeyToWifString(test.input); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		} else if privateWif != test.expectedWif {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but failed comparison of keys, got: %s", t.Name(), test.input, test.expectedWif, privateWif)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			privateWif, err := PrivateKeyToWifString(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedWif, privateWif)
+		})
 	}
 }
 
@@ -280,7 +290,7 @@ func ExamplePrivateKeyToWifString() {
 // BenchmarkPrivateKeyToWifString benchmarks the method PrivateKeyToWifString()
 func BenchmarkPrivateKeyToWifString(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = PrivateKeyToWifString(key)
 	}
 }
@@ -290,42 +300,43 @@ func TestWifToPrivateKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedKey   string
 		expectedNil   bool
 		expectedError bool
 	}{
-		{"", "", true, true},
-		{"0", "", true, true},
-		{"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", "0000000000000000000000000000000000000000000000000000000000000000", false, false},
-		{"5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", "0000000000000000000000000000000000006d792070726976617465206b6579", false, false},
-		{"54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true, true},
-		{"5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei", testPrivateKeyHex, false, false},
+		{caseEmpty, "", "", true, true},
+		{caseSingleZero, "0", "", true, true},
+		{"zeros wif", "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", "0000000000000000000000000000000000000000000000000000000000000000", false, false},
+		{"ascii key wif", "5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", "0000000000000000000000000000000000006d792070726976617465206b6579", false, false},
+		{"invalid wif", "54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true, true},
+		{"valid uncompressed wif", testUncompressedWIF, testPrivateKeyHex, false, false},
 	}
 
 	for _, test := range tests {
-		privateKey, err := WifToPrivateKey(test.input)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		}
-		if privateKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was nil but not expected", t.Name(), test.input)
-		}
-		if privateKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was NOT nil but expected to be nil", t.Name(), test.input)
-		}
-		if privateKey != nil && hex.EncodeToString(privateKey.Serialize()) != test.expectedKey {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but failed comparison of keys, got: %s", t.Name(), test.input, test.expectedKey, hex.EncodeToString(privateKey.Serialize()))
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			privateKey, err := WifToPrivateKey(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, privateKey)
+			} else {
+				require.NotNil(t, privateKey)
+				assert.Equal(t, test.expectedKey, hex.EncodeToString(privateKey.Serialize()))
+			}
+		})
 	}
 }
 
 // ExampleWifToPrivateKey example using WifToPrivateKey()
 func ExampleWifToPrivateKey() {
-	privateKey, err := WifToPrivateKey("5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei")
+	privateKey, err := WifToPrivateKey(testUncompressedWIF)
 	if err != nil {
 		fmt.Printf("error occurred: %s", err.Error())
 		return
@@ -337,8 +348,8 @@ func ExampleWifToPrivateKey() {
 
 // BenchmarkWifToPrivateKey benchmarks the method WifToPrivateKey()
 func BenchmarkWifToPrivateKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, _ = WifToPrivateKey("5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei")
+	for b.Loop() {
+		_, _ = WifToPrivateKey(testUncompressedWIF)
 	}
 }
 
@@ -347,32 +358,37 @@ func TestWifToPrivateKeyString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		input         string
 		expectedKey   string
 		expectedError bool
 	}{
-		{"", "", true},
-		{"0", "", true},
-		{"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", "0000000000000000000000000000000000000000000000000000000000000000", false},
-		{"5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", "0000000000000000000000000000000000006d792070726976617465206b6579", false},
-		{"54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true},
-		{"5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei", testPrivateKeyHex, false},
+		{caseEmpty, "", "", true},
+		{caseSingleZero, "0", "", true},
+		{"zeros wif", "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU", "0000000000000000000000000000000000000000000000000000000000000000", false},
+		{"ascii key wif", "5HpHagT65TZzG1PH3CSu63k8DbuTZnNJf6HgyQNymvXmALAsm9s", "0000000000000000000000000000000000006d792070726976617465206b6579", false},
+		{"invalid wif", "54035dd4c7dda99ac473905a3d82f7864322b49bab1ff441cc457183b9bd8azz", "", true},
+		{"valid uncompressed wif", testUncompressedWIF, testPrivateKeyHex, false},
 	}
 
 	for _, test := range tests {
-		if privateKey, err := WifToPrivateKeyString(test.input); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.input, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.input)
-		} else if privateKey != test.expectedKey {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but failed comparison of keys, got: %s", t.Name(), test.input, test.expectedKey, privateKey)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			privateKey, err := WifToPrivateKeyString(test.input)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedKey, privateKey)
+		})
 	}
 }
 
 // ExampleWifToPrivateKeyString example using WifToPrivateKeyString()
 func ExampleWifToPrivateKeyString() {
-	privateKey, err := WifToPrivateKeyString("5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei")
+	privateKey, err := WifToPrivateKeyString(testUncompressedWIF)
 	if err != nil {
 		fmt.Printf("error occurred: %s", err.Error())
 		return
@@ -384,8 +400,8 @@ func ExampleWifToPrivateKeyString() {
 
 // BenchmarkWifToPrivateKeyString benchmarks the method WifToPrivateKeyString()
 func BenchmarkWifToPrivateKeyString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, _ = WifToPrivateKeyString("5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei")
+	for b.Loop() {
+		_, _ = WifToPrivateKeyString(testUncompressedWIF)
 	}
 }
 
@@ -436,7 +452,7 @@ func ExampleCreateWif() {
 
 // BenchmarkCreateWif benchmarks the method CreateWif()
 func BenchmarkCreateWif(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreateWif()
 	}
 }
@@ -487,7 +503,7 @@ func ExampleCreateWifString() {
 
 // BenchmarkCreateWifString benchmarks the method CreateWifString()
 func BenchmarkCreateWifString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreateWifString()
 	}
 }
@@ -583,7 +599,7 @@ func ExampleWifFromString() {
 func BenchmarkWifFromString(b *testing.B) {
 	wifKey, _ := CreateWif()
 	wifString := wifKey.String()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = WifFromString(wifString)
 	}
 }

--- a/pubkey.go
+++ b/pubkey.go
@@ -27,7 +27,7 @@ func PubKeyFromPrivateKey(privateKey *ec.PrivateKey, compressed bool) string {
 // PubKeyFromString will convert a pubKey (string) into a pubkey (*ec.PublicKey)
 func PubKeyFromString(pubKey string) (*ec.PublicKey, error) {
 	// Invalid pubKey
-	if len(pubKey) == 0 {
+	if pubKey == "" {
 		return nil, ErrMissingPubKey
 	}
 

--- a/pubkey_test.go
+++ b/pubkey_test.go
@@ -15,25 +15,30 @@ func TestPubKeyFromPrivateKeyString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name           string
 		inputKey       string
 		expectedPubKey string
 		compressed     bool
 		expectedError  bool
 	}{
-		{testPrivateKeyHex, "031b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f", true, false},
-		{testPrivateKeyHex, "041b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f36e7ef720509250313fcf1b4c5af0dc7c5efa126efe2c3b7008e6f1487c61f31", false, false},
-		{"0", "", true, true},
-		{"", "", true, true},
+		{"compressed", testPrivateKeyHex, testPubKeyCompressed, true, false},
+		{"uncompressed", testPrivateKeyHex, testPubKeyUncompressed, false, false},
+		{caseSingleZero, "0", "", true, true},
+		{caseEmpty, "", "", true, true},
 	}
 
 	for _, test := range tests {
-		if pubKey, err := PubKeyFromPrivateKeyString(test.inputKey, test.compressed); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.inputKey, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.inputKey)
-		} else if pubKey != test.expectedPubKey {
-			t.Fatalf("%s Failed: [%s] inputted and [%s] expected, but got: %s", t.Name(), test.inputKey, test.expectedPubKey, pubKey)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			pubKey, err := PubKeyFromPrivateKeyString(test.inputKey, test.compressed)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedPubKey, pubKey)
+		})
 	}
 }
 
@@ -51,7 +56,7 @@ func ExamplePubKeyFromPrivateKeyString() {
 // BenchmarkPubKeyFromPrivateKeyString benchmarks the method PubKeyFromPrivateKeyString()
 func BenchmarkPubKeyFromPrivateKeyString(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = PubKeyFromPrivateKeyString(key, true)
 	}
 }
@@ -65,17 +70,21 @@ func TestPubKeyFromPrivateKey(t *testing.T) {
 	assert.NotNil(t, priv)
 
 	tests := []struct {
+		name           string
 		inputKey       *ec.PrivateKey
 		expectedPubKey string
 		expectedError  bool
 	}{
-		{priv, "031b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f", false},
+		{"compressed", priv, testPubKeyCompressed, false},
 	}
 
 	for _, test := range tests {
-		if pubKey := PubKeyFromPrivateKey(test.inputKey, true); pubKey != test.expectedPubKey {
-			t.Fatalf("%s Failed: [%v] inputted and [%s] expected, but got: %s", t.Name(), test.inputKey, test.expectedPubKey, pubKey)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			pubKey := PubKeyFromPrivateKey(test.inputKey, true)
+			assert.Equal(t, test.expectedPubKey, pubKey)
+		})
 	}
 }
 
@@ -105,7 +114,7 @@ func ExamplePubKeyFromPrivateKey() {
 // BenchmarkPubKeyFromPrivateKey benchmarks the method PubKeyFromPrivateKey()
 func BenchmarkPubKeyFromPrivateKey(b *testing.B) {
 	key, _ := CreatePrivateKey()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = PubKeyFromPrivateKey(key, true)
 	}
 }
@@ -115,40 +124,41 @@ func TestPubKeyFromString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name           string
 		inputKey       string
 		expectedPubKey string
 		expectedNil    bool
 		expectedError  bool
 	}{
-		{"", "", true, true},
-		{"0", "", true, true},
-		{"00000", "", true, true},
-		{"031b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f", "031b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f", false, false},
+		{caseEmpty, "", "", true, true},
+		{caseSingleZero, "0", "", true, true},
+		{"short zeros", "00000", "", true, true},
+		{"valid compressed", testPubKeyCompressed, testPubKeyCompressed, false, false},
 	}
 
 	for _, test := range tests {
-		pubKey, err := PubKeyFromString(test.inputKey)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.inputKey, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.inputKey)
-		}
-		if pubKey != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and nil was expected", t.Name(), test.inputKey)
-		}
-		if pubKey == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and nil was NOT expected", t.Name(), test.inputKey)
-		}
-		if pubKey != nil && hex.EncodeToString(pubKey.Compressed()) != test.expectedPubKey {
-			t.Fatalf("%s Failed: [%s] inputted and [%s] expected, but got: %s", t.Name(), test.inputKey, test.expectedPubKey, hex.EncodeToString(pubKey.Compressed()))
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			pubKey, err := PubKeyFromString(test.inputKey)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, pubKey)
+			} else {
+				require.NotNil(t, pubKey)
+				assert.Equal(t, test.expectedPubKey, hex.EncodeToString(pubKey.Compressed()))
+			}
+		})
 	}
 }
 
 // ExamplePubKeyFromString example using PubKeyFromString()
 func ExamplePubKeyFromString() {
-	pubKey, err := PubKeyFromString("031b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f")
+	pubKey, err := PubKeyFromString(testPubKeyCompressed)
 	if err != nil {
 		fmt.Printf("error occurred: %s", err.Error())
 		return
@@ -159,7 +169,7 @@ func ExamplePubKeyFromString() {
 
 // BenchmarkPubKeyFromString benchmarks the method PubKeyFromString()
 func BenchmarkPubKeyFromString(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, _ = PubKeyFromString("031b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f")
+	for b.Loop() {
+		_, _ = PubKeyFromString(testPubKeyCompressed)
 	}
 }

--- a/script.go
+++ b/script.go
@@ -7,7 +7,7 @@ import (
 // ScriptFromAddress will create an output P2PKH script from an address string
 func ScriptFromAddress(address string) (string, error) {
 	// Missing address?
-	if len(address) == 0 {
+	if address == "" {
 		return "", ErrMissingAddress
 	}
 

--- a/script_test.go
+++ b/script_test.go
@@ -3,6 +3,9 @@ package bitcoin
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestScriptFromAddress will test the method ScriptFromAddress()
@@ -10,25 +13,30 @@ func TestScriptFromAddress(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name           string
 		inputAddress   string
 		expectedScript string
 		expectedError  bool
 	}{
-		{"", "", true},
-		{"0", "", true},
-		{"1234567", "", true},
-		{"1HRVqUGDzpZSMVuNSZxJVaB9xjneEShfA7", "76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2996388ac", false},
-		{"13Rj7G3pn2GgG8KE6SFXLc7dCJdLNnNK7M", "76a9141a9d62736746f85ca872dc555ff51b1fed2471e288ac", false},
+		{"empty address", "", "", true},
+		{caseSingleZero, "0", "", true},
+		{"too short", "1234567", "", true},
+		{"valid address 1", "1HRVqUGDzpZSMVuNSZxJVaB9xjneEShfA7", "76a914b424110292f4ea2ac92beb9e83cf5e6f0fa2996388ac", false},
+		{"valid address 2", "13Rj7G3pn2GgG8KE6SFXLc7dCJdLNnNK7M", "76a9141a9d62736746f85ca872dc555ff51b1fed2471e288ac", false},
 	}
 
 	for _, test := range tests {
-		if script, err := ScriptFromAddress(test.inputAddress); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error not expected but got: %s", t.Name(), test.inputAddress, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] inputted and error was expected", t.Name(), test.inputAddress)
-		} else if script != test.expectedScript {
-			t.Fatalf("%s Failed: [%v] inputted [%s] expected but failed comparison of scripts, got: %s", t.Name(), test.inputAddress, test.expectedScript, script)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			script, err := ScriptFromAddress(test.inputAddress)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.expectedScript, script)
+		})
 	}
 }
 
@@ -45,7 +53,7 @@ func ExampleScriptFromAddress() {
 
 // BenchmarkScriptFromAddress benchmarks the method ScriptFromAddress()
 func BenchmarkScriptFromAddress(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = ScriptFromAddress("1HRVqUGDzpZSMVuNSZxJVaB9xjneEShfA7")
 	}
 }

--- a/sign.go
+++ b/sign.go
@@ -10,7 +10,7 @@ import (
 // sigRefCompressedKey bool determines whether the signature will reference a compressed or uncompresed key
 // Spec: https://docs.moneybutton.com/docs/bsv-message.html
 func SignMessage(privateKey, message string, sigRefCompressedKey bool) (string, error) {
-	if len(privateKey) == 0 {
+	if privateKey == "" {
 		return "", ErrPrivateKeyMissing
 	}
 

--- a/sign_test.go
+++ b/sign_test.go
@@ -3,41 +3,33 @@ package bitcoin
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSigningCompression(t *testing.T) {
+	t.Parallel()
+
 	testKey := "0499f8239bfe10eb0f5e53d543635a423c96529dd85fa4bad42049a0b435ebdd"
 	testData := "test message"
 
 	// Test sign uncompressed
 	address, err := GetAddressFromPrivateKeyString(testKey, false, true)
-	if err != nil {
-		t.Errorf("Get address err %s", err)
-	}
-	sig, err := SignMessage(testKey, testData, false)
-	if err != nil {
-		t.Errorf("Failed to sign uncompressed %s", err)
-	}
+	require.NoError(t, err)
 
-	err = VerifyMessage(address, sig, testData, true)
-	if err != nil {
-		t.Errorf("Failed to validate uncompressed %s", err)
-	}
+	sig, err := SignMessage(testKey, testData, false)
+	require.NoError(t, err)
+
+	require.NoError(t, VerifyMessage(address, sig, testData, true))
 
 	// Test sign compressed
 	address, err = GetAddressFromPrivateKeyString(testKey, true, true)
-	if err != nil {
-		t.Errorf("Get address err %s", err)
-	}
-	sig, err = SignMessage(testKey, testData, true)
-	if err != nil {
-		t.Errorf("Failed to sign compressed %s", err)
-	}
+	require.NoError(t, err)
 
-	err = VerifyMessage(address, sig, testData, true)
-	if err != nil {
-		t.Errorf("Failed to validate compressed %s", err)
-	}
+	sig, err = SignMessage(testKey, testData, true)
+	require.NoError(t, err)
+
+	require.NoError(t, VerifyMessage(address, sig, testData, true))
 }
 
 // TestSignMessage will test the method SignMessage()
@@ -45,72 +37,84 @@ func TestSignMessage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name              string
 		inputKey          string
 		inputMessage      string
 		expectedSignature string
 		expectedError     bool
 	}{
 		{
+			"valid key and message",
 			"0499f8239bfe10eb0f5e53d543635a423c96529dd85fa4bad42049a0b435ebdd",
 			"test message",
 			"HFxPx8JHsCiivB+DW/RgNpCLT6yG3j436cUNWKekV3ORBrHNChIjeVReyAco7PVmmDtVD3POs9FhDlm/nk5I6O8=",
 			false,
 		},
 		{
+			"second valid key",
 			"ef0b8bad0be285099534277fde328f8f19b3be9cadcd4c08e6ac0b5f863745ac",
 			"This is a test message",
 			"G+zZagsyz7ioC/ZOa5EwsaKice0vs2BvZ0ljgkFHxD3vGsMlGeD4sXHEcfbI4h8lP29VitSBdf4A+nHXih7svf4=",
 			false,
 		},
 		{
+			"long message",
 			"0499f8239bfe10eb0f5e53d543635a423c96529dd85fa4bad42049a0b435ebdd",
 			"This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af. This time I'm writing a new message that is obnixiously long af.",
 			"GxRcFXQc7LHxFNpK5lzhR+LF5ixIvhB089bxYzTAV02yGHm/3ALxltz/W4lGp77Q5UTxdj+TU+96mdAcJ5b/fGs=",
 			false,
 		},
 		{
+			"third valid key",
 			"93596babb564cbbdc84f2370c710b9bcc94333495b60af719b5fcf9ba00ba82c",
 			"This is a test message",
 			"HIuDw09ffPgEDuxEw5yHVp1+mi4QpuhAwLyQdpMTfsHCOkMqTKXuP7dSNWMEJqZsiQ8eKMDRvf2wZ4e5bxcu4O0=",
 			false,
 		},
 		{
+			"fourth valid key",
 			"50381cf8f52936faae4a05a073a03d688a9fa206d005e87a39da436c75476d78",
 			"This is a test message",
 			"HLBmbjCY2Z7eSXGXZoBI3x2ZRaYUYOGtEaDjXetaY+zNDtMOvagsOGEHnVT3f5kXlEbuvmPydHqLnyvZP3cDOWk=",
 			false,
 		},
 		{
+			"fifth valid key",
 			"c7726663147afd1add392d129086e57c0b05aa66a6ded564433c04bd55741434",
 			"This is a test message",
 			"HOI207QUnTLr2Ll+s4kUxNgLgorkc/Z5Pc+XNvUBYLy2TxaU6oHEJ2TTJ1mZVrtUyHm6e315v1tIjeosW3Odfqw=",
 			false,
 		},
 		{
+			"single char message",
 			"c7726663147afd1add392d129086e57c0b05aa66a6ded564433c04bd55741434",
 			"1",
 			"HMcRFG1VNN9TDGXpCU+9CqKLNOuhwQiXI5hZpkTOuYHKBDOWayNuAABofYLqUHYTMiMf9mYFQ0sPgFJZz3F7ELQ=",
 			false,
 		},
 		{
+			"empty key errors",
 			"",
 			"This is a test message",
 			"",
 			true,
 		},
 		{
+			"invalid key 0 errors",
 			"0",
 			"This is a test message",
 			"",
 			true,
 		},
 		{
+			"odd length key errors",
 			"0000000",
 			"This is a test message",
 			"",
 			true,
 		},
 		{
+			"short key still signs",
 			"c7726663147afd1add392d129086e57c0b",
 			"This is a test message",
 			"G6N+iPf23i2YkLsNzF/yyeBm9eSYBoY/HFV1Md1F0ElWBXW5E5mkdRtgjoRuq0yNb1CCFNWWlkn2gZknFJNUFJ8=",
@@ -118,14 +122,17 @@ func TestSignMessage(t *testing.T) {
 		},
 	}
 
-	for idx, test := range tests {
-		if signature, err := SignMessage(test.inputKey, test.inputMessage, false); err != nil && !test.expectedError {
-			t.Fatalf("%d %s Failed: [%s] [%s] inputted and error not expected but got: %s", idx, t.Name(), test.inputKey, test.inputMessage, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%d %s Failed: [%s] [%s] inputted and error was expected", idx, t.Name(), test.inputKey, test.inputMessage)
-		} else if signature != test.expectedSignature {
-			t.Fatalf("%d %s Failed: [%s] [%s] inputted [%s] expected but got: %s", idx, t.Name(), test.inputKey, test.inputMessage, test.expectedSignature, signature)
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			signature, err := SignMessage(test.inputKey, test.inputMessage, false)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.expectedSignature, signature)
+		})
 	}
 }
 
@@ -143,7 +150,7 @@ func ExampleSignMessage() {
 // BenchmarkSignMessage benchmarks the method SignMessage()
 func BenchmarkSignMessage(b *testing.B) {
 	key, _ := CreatePrivateKeyString()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = SignMessage(key, "This is a test message", false)
 	}
 }

--- a/sign_verify_extended_test.go
+++ b/sign_verify_extended_test.go
@@ -66,6 +66,7 @@ func TestSignMessageExtended(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			signature, err := SignMessage(tt.privateKey, tt.message, tt.sigRefCompressedKey)
 
 			if tt.shouldError {
@@ -93,6 +94,7 @@ func TestPubKeyFromSignatureExtended(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("valid signature", func(t *testing.T) {
+		t.Parallel()
 		pubKey, wasCompressed, err := PubKeyFromSignature(signature, message)
 		require.NoError(t, err)
 		assert.NotNil(t, pubKey)
@@ -100,18 +102,21 @@ func TestPubKeyFromSignatureExtended(t *testing.T) {
 	})
 
 	t.Run("invalid base64 signature", func(t *testing.T) {
+		t.Parallel()
 		pubKey, _, err := PubKeyFromSignature("not-base64!@#", message)
 		require.Error(t, err)
 		assert.Nil(t, pubKey)
 	})
 
 	t.Run("empty signature", func(t *testing.T) {
+		t.Parallel()
 		pubKey, _, err := PubKeyFromSignature("", message)
 		require.Error(t, err)
 		assert.Nil(t, pubKey)
 	})
 
 	t.Run("wrong message", func(t *testing.T) {
+		t.Parallel()
 		// Using a different message should still recover a pubkey, but verification would fail
 		pubKey, wasCompressed, err := PubKeyFromSignature(signature, "Different message")
 		// This might succeed or fail depending on implementation
@@ -140,27 +145,32 @@ func TestVerifyMessageExtended(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("valid signature and address - mainnet", func(t *testing.T) {
+		t.Parallel()
 		err := VerifyMessage(address, signature, message, true)
 		require.NoError(t, err)
 	})
 
 	t.Run("wrong address", func(t *testing.T) {
+		t.Parallel()
 		err := VerifyMessage("1C8bzHM8XFBHZ2ZZVvFy2NSoAZbwCXAicL", signature, message, true)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("wrong message", func(t *testing.T) {
+		t.Parallel()
 		err := VerifyMessage(address, signature, "Wrong message", true)
 		require.Error(t, err)
 	})
 
 	t.Run("invalid signature", func(t *testing.T) {
+		t.Parallel()
 		err := VerifyMessage(address, "invalid-signature", message, true)
 		require.Error(t, err)
 	})
 
 	t.Run("empty signature", func(t *testing.T) {
+		t.Parallel()
 		err := VerifyMessage(address, "", message, true)
 		require.Error(t, err)
 	})
@@ -234,6 +244,7 @@ func TestVerifyMessageDERExtended(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			verified, err := VerifyMessageDER(tt.hash, tt.pubKey, tt.signature)
 
 			if tt.shouldError {

--- a/test_constants_test.go
+++ b/test_constants_test.go
@@ -7,4 +7,21 @@ const (
 	testScriptPubKey  = "76a9149cbe9f5e72fa286ac8a38052d1d5337aa363ea7f88ac"
 	testAddress       = "1C8bzHM8XFBHZ2ZZVvFy2NSoAZbwCXAicL"
 	testAddress2      = "1CU8AAJoPTvLCph2mnpXarExQ1rKdVZum5"
+
+	// testChangeAddress is the change address reused across the transaction tests.
+	testChangeAddress = "1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc"
+
+	// testUncompressedWIF / testCompressedWIF are the mainnet WIF encodings of
+	// testPrivateKeyHex (uncompressed leads with '5', compressed with 'K'/'L').
+	testUncompressedWIF = "5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei"
+	testCompressedWIF   = "Kz32CUDnArL4eZrGM5NDMhJ5FrduV2MnumwEUePN3TP8AwSRRFvQ"
+
+	// testPubKeyCompressed / testPubKeyUncompressed are the public key of
+	// testPrivateKeyHex in hex (compressed = 33 bytes, uncompressed = 65 bytes).
+	testPubKeyCompressed   = "031b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f"
+	testPubKeyUncompressed = "041b8c93100d35bd448f4646cc4678f278351b439b52b303ea31ec9edb5475e73f36e7ef720509250313fcf1b4c5af0dc7c5efa126efe2c3b7008e6f1487c61f31"
+
+	// Frequently reused table-test case names (kept as constants for goconst).
+	caseEmpty      = "empty"
+	caseSingleZero = "single zero"
 )

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -1,0 +1,48 @@
+package bitcoin
+
+import (
+	"testing"
+
+	bip32 "github.com/bsv-blockchain/go-sdk/compat/bip32"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestUtxo returns a *Utxo seeded with the shared test tx id / script and the
+// given satoshi value. It centralizes the Utxo literal repeated across the
+// transaction tests.
+func newTestUtxo(satoshis uint64) *Utxo {
+	return &Utxo{
+		TxID:         testTxID,
+		Vout:         0,
+		ScriptPubKey: testScriptPubKey,
+		Satoshis:     satoshis,
+	}
+}
+
+// newTestOpReturns returns the standard two-element OpReturnData slice used
+// throughout the transaction tests.
+func newTestOpReturns() []OpReturnData {
+	return []OpReturnData{
+		{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}},
+		{[]byte("prefix2"), []byte("more example data")},
+	}
+}
+
+// mustTestPrivKey decodes the shared test WIF into an *ec.PrivateKey, failing the
+// test on error.
+func mustTestPrivKey(t *testing.T) *ec.PrivateKey {
+	t.Helper()
+	privateKey, err := WifToPrivateKey(testWIF)
+	require.NoError(t, err)
+	return privateKey
+}
+
+// mustHDKey generates an HD master key with the recommended seed length, failing
+// the test on error.
+func mustHDKey(t *testing.T) *bip32.ExtendedKey {
+	t.Helper()
+	key, err := GenerateHDKey(RecommendedSeedLength)
+	require.NoError(t, err)
+	return key
+}

--- a/transaction.go
+++ b/transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/bsv-blockchain/go-bt/v2"
@@ -24,6 +25,11 @@ const (
 	// DustLimit is the minimum value for a tx that can be spent
 	// This is being deprecated in the new node software (TBD)
 	DustLimit uint64 = 546
+
+	// opReturnPrefix is the locking-script hex prefix for a bare OP_RETURN output.
+	opReturnPrefix = "6a"
+	// opFalseReturnPrefix is the locking-script hex prefix for an OP_FALSE OP_RETURN output.
+	opFalseReturnPrefix = "006a"
 )
 
 // Utxo is an unspent transaction output
@@ -71,7 +77,7 @@ func CreateTxWithChange(utxos []*Utxo, payToAddresses []*PayToAddress, opReturns
 	// Missing utxo(s) or change address
 	if len(utxos) == 0 {
 		return nil, ErrUtxosRequired
-	} else if len(changeAddress) == 0 {
+	} else if changeAddress == "" {
 		return nil, ErrChangeAddressRequired
 	}
 
@@ -156,9 +162,9 @@ func CreateTxWithChange(utxos []*Utxo, payToAddresses []*PayToAddress, opReturns
 
 	// Remove remainder from last used payToAddress (or continue until found)
 	feeAdjusted := false
-	for i := len(payToAddresses) - 1; i >= 0; i-- { // Working backwards
-		if payToAddresses[i].Satoshis > remainder {
-			payToAddresses[i].Satoshis = payToAddresses[i].Satoshis - remainder
+	for _, payTo := range slices.Backward(payToAddresses) { // Working backwards
+		if payTo.Satoshis > remainder {
+			payTo.Satoshis -= remainder
 			feeAdjusted = true
 			break
 		}
@@ -341,7 +347,7 @@ func CalculateFeeForTx(tx *bt.Tx, standardRate, dataRate *bt.Fee) uint64 {
 	// Loop all outputs and accumulate size (find data related outputs)
 	for _, out := range tx.Outputs {
 		outHexString := out.LockingScriptHexString()
-		if strings.HasPrefix(outHexString, "006a") || strings.HasPrefix(outHexString, "6a") {
+		if strings.HasPrefix(outHexString, opFalseReturnPrefix) || strings.HasPrefix(outHexString, opReturnPrefix) {
 			totalDataBytes += len(out.Bytes())
 		}
 	}
@@ -357,13 +363,8 @@ func CalculateFeeForTx(tx *bt.Tx, standardRate, dataRate *bt.Fee) uint64 {
 		totalFee += (standardRate.MiningFee.Satoshis * totalBytes) / standardRate.MiningFee.Bytes
 	}
 
-	// Safety check (possible division by zero?)
-	if totalFee == 0 {
-		totalFee = 1
-	}
-
-	// Safety check for negative fee (should never happen in practice)
-	if totalFee < 0 {
+	// Safety check: never return a zero (rounding/division) or negative fee
+	if totalFee <= 0 {
 		totalFee = 1
 	}
 

--- a/transaction_creation_test.go
+++ b/transaction_creation_test.go
@@ -23,7 +23,7 @@ func TestCreateTxExtended(t *testing.T) {
 		utxos       []*Utxo
 		addresses   []*PayToAddress
 		opReturns   []OpReturnData
-		privateKey  interface{} // Can be nil or *ec.PrivateKey
+		privateKey  any // Can be nil or *ec.PrivateKey
 		shouldError bool
 		errorText   string
 	}{
@@ -185,6 +185,7 @@ func TestCreateTxExtended(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var tx *bt.Tx
 			var err error
 
@@ -220,12 +221,7 @@ func TestCreateTxExtended(t *testing.T) {
 func TestCreateTxUsingWifExtended(t *testing.T) {
 	t.Parallel()
 
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     10000,
-	}
+	utxo := newTestUtxo(10000)
 
 	address := &PayToAddress{
 		Address:  testAddress,
@@ -233,18 +229,21 @@ func TestCreateTxUsingWifExtended(t *testing.T) {
 	}
 
 	t.Run("valid wif", func(t *testing.T) {
+		t.Parallel()
 		tx, err := CreateTxUsingWif([]*Utxo{utxo}, []*PayToAddress{address}, nil, testWIF)
 		require.NoError(t, err)
 		assert.NotNil(t, tx)
 	})
 
 	t.Run("invalid wif", func(t *testing.T) {
+		t.Parallel()
 		tx, err := CreateTxUsingWif([]*Utxo{utxo}, []*PayToAddress{address}, nil, "invalid-wif")
 		require.Error(t, err)
 		assert.Nil(t, tx)
 	})
 
 	t.Run("empty wif", func(t *testing.T) {
+		t.Parallel()
 		tx, err := CreateTxUsingWif([]*Utxo{utxo}, []*PayToAddress{address}, nil, "")
 		require.Error(t, err)
 		assert.Nil(t, tx)
@@ -256,15 +255,9 @@ func TestCalculateFeeForTxExtended(t *testing.T) {
 	t.Parallel()
 
 	// Create a simple transaction for testing
-	privateKey, err := WifToPrivateKey(testWIF)
-	require.NoError(t, err)
+	privateKey := mustTestPrivKey(t)
 
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     10000,
-	}
+	utxo := newTestUtxo(10000)
 
 	address := &PayToAddress{
 		Address:  testAddress,
@@ -275,11 +268,13 @@ func TestCalculateFeeForTxExtended(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("calculate fee with default rates", func(t *testing.T) {
+		t.Parallel()
 		fee := CalculateFeeForTx(tx, nil, nil)
 		assert.Positive(t, fee, "Fee should be greater than 0")
 	})
 
 	t.Run("calculate fee with custom standard rate", func(t *testing.T) {
+		t.Parallel()
 		customRate := &bt.Fee{
 			FeeType: bt.FeeTypeStandard,
 			MiningFee: bt.FeeUnit{
@@ -296,6 +291,7 @@ func TestCalculateFeeForTxExtended(t *testing.T) {
 	})
 
 	t.Run("calculate fee with custom data rate", func(t *testing.T) {
+		t.Parallel()
 		customDataRate := &bt.Fee{
 			FeeType: bt.FeeTypeData,
 			MiningFee: bt.FeeUnit{
@@ -312,6 +308,7 @@ func TestCalculateFeeForTxExtended(t *testing.T) {
 	})
 
 	t.Run("calculate fee for transaction with OP_RETURN", func(t *testing.T) {
+		t.Parallel()
 		txWithOpReturn, err := CreateTx(
 			[]*Utxo{utxo},
 			[]*PayToAddress{address},
@@ -329,6 +326,7 @@ func TestCalculateFeeForTxExtended(t *testing.T) {
 	})
 
 	t.Run("zero-cost rate clamps fee to 1", func(t *testing.T) {
+		t.Parallel()
 		zeroRate := &bt.Fee{
 			FeeType:   bt.FeeTypeStandard,
 			MiningFee: bt.FeeUnit{Satoshis: 0, Bytes: 10},
@@ -339,6 +337,7 @@ func TestCalculateFeeForTxExtended(t *testing.T) {
 	})
 
 	t.Run("negative rate clamps fee to 1", func(t *testing.T) {
+		t.Parallel()
 		negativeRate := &bt.Fee{
 			FeeType:   bt.FeeTypeStandard,
 			MiningFee: bt.FeeUnit{Satoshis: -10, Bytes: 10},
@@ -355,8 +354,7 @@ func TestCalculateFeeForTxExtended(t *testing.T) {
 func TestCreateTxNonP2PKHUtxoFailsSigning(t *testing.T) {
 	t.Parallel()
 
-	privateKey, err := WifToPrivateKey(testWIF)
-	require.NoError(t, err)
+	privateKey := mustTestPrivKey(t)
 
 	// A data (OP_FALSE OP_RETURN) locking script is not P2PKH
 	utxo := &Utxo{
@@ -382,8 +380,7 @@ func TestCreateTxNonP2PKHUtxoFailsSigning(t *testing.T) {
 func TestCreateTxWithChangeFeeRerunRemainder(t *testing.T) {
 	t.Parallel()
 
-	privateKey, err := WifToPrivateKey(testWIF)
-	require.NoError(t, err)
+	privateKey := mustTestPrivKey(t)
 
 	// With a 50 sat/byte rate: feeNoChange ~9601, feeWithChange ~11251.
 	// leftover (10500) sits between them, so the change-included draft pushes the
@@ -421,10 +418,10 @@ func TestCreateTxWithChangeFeeRerunRemainder(t *testing.T) {
 func TestCreateTxWithChangeExtended(t *testing.T) {
 	t.Parallel()
 
-	privateKey, err := WifToPrivateKey(testWIF)
-	require.NoError(t, err)
+	privateKey := mustTestPrivKey(t)
 
 	t.Run("create tx with change - basic", func(t *testing.T) {
+		t.Parallel()
 		utxos := []*Utxo{
 			{
 				TxID:         testTxID,
@@ -449,6 +446,7 @@ func TestCreateTxWithChangeExtended(t *testing.T) {
 	})
 
 	t.Run("no utxos - should error", func(t *testing.T) {
+		t.Parallel()
 		addresses := []*PayToAddress{
 			{
 				Address:  testAddress,
@@ -463,6 +461,7 @@ func TestCreateTxWithChangeExtended(t *testing.T) {
 	})
 
 	t.Run("no change address - should error", func(t *testing.T) {
+		t.Parallel()
 		utxos := []*Utxo{
 			{
 				TxID:         testTxID,
@@ -486,6 +485,7 @@ func TestCreateTxWithChangeExtended(t *testing.T) {
 	})
 
 	t.Run("insufficient funds - should error", func(t *testing.T) {
+		t.Parallel()
 		utxos := []*Utxo{
 			{
 				TxID:         testTxID,
@@ -509,6 +509,7 @@ func TestCreateTxWithChangeExtended(t *testing.T) {
 	})
 
 	t.Run("exact amount - no change needed", func(t *testing.T) {
+		t.Parallel()
 		// When paying exact amount, no change output should be created
 		// This test verifies the edge case handling
 		utxos := []*Utxo{
@@ -559,12 +560,14 @@ func TestCreateTxWithChangeUsingWifExtended(t *testing.T) {
 	}
 
 	t.Run("valid wif", func(t *testing.T) {
+		t.Parallel()
 		tx, err := CreateTxWithChangeUsingWif(utxos, addresses, nil, testAddress, nil, nil, testWIF)
 		require.NoError(t, err)
 		assert.NotNil(t, tx)
 	})
 
 	t.Run("invalid wif", func(t *testing.T) {
+		t.Parallel()
 		tx, err := CreateTxWithChangeUsingWif(utxos, addresses, nil, testAddress, nil, nil, "invalid-wif")
 		require.Error(t, err)
 		assert.Nil(t, tx)
@@ -574,18 +577,13 @@ func TestCreateTxWithChangeUsingWifExtended(t *testing.T) {
 // BenchmarkCreateTxExtended benchmarks the CreateTx function with different scenarios
 func BenchmarkCreateTxExtended(b *testing.B) {
 	privateKey, _ := WifToPrivateKey(testWIF)
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     10000,
-	}
+	utxo := newTestUtxo(10000)
 	address := &PayToAddress{
 		Address:  testAddress,
 		Satoshis: 5000,
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreateTx([]*Utxo{utxo}, []*PayToAddress{address}, nil, privateKey)
 	}
 }
@@ -593,19 +591,14 @@ func BenchmarkCreateTxExtended(b *testing.B) {
 // BenchmarkCalculateFeeForTxExtended benchmarks the CalculateFeeForTx function
 func BenchmarkCalculateFeeForTxExtended(b *testing.B) {
 	privateKey, _ := WifToPrivateKey(testWIF)
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     10000,
-	}
+	utxo := newTestUtxo(10000)
 	address := &PayToAddress{
 		Address:  testAddress,
 		Satoshis: 5000,
 	}
 	tx, _ := CreateTx([]*Utxo{utxo}, []*PayToAddress{address}, nil, privateKey)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = CalculateFeeForTx(tx, nil, nil)
 	}
 }

--- a/transaction_fuzz_test.go
+++ b/transaction_fuzz_test.go
@@ -1,0 +1,23 @@
+package bitcoin
+
+import (
+	"testing"
+)
+
+// FuzzTxFromHex tests TxFromHex with various raw hex strings to ensure it never
+// panics regardless of input.
+func FuzzTxFromHex(f *testing.F) {
+	// Seed corpus with valid and invalid raw transaction hex
+	f.Add("01000000012adda020db81f2155ebba69e7c841275517ebf91674268c32ff2f5c7e2853b2c010000006b483045022100872051ef0b6c47714130c12a067db4f38b988bfc22fe270731c2146f5229386b02207abf68bbf092ec03e2c616defcc4c868ad1fc3cdbffb34bcedfab391a1274f3e412102affe8c91d0a61235a3d07b1903476a2e2f7a90451b2ed592fea9937696a07077ffffffff02ed1a0000000000001976a91491b3753cf827f139d2dc654ce36f05331138ddb588acc9670300000000001976a914da036233873cc6489ff65a0185e207d243b5154888ac00000000")
+	f.Add("")
+	f.Add("0")
+	f.Add("00")
+	f.Add("bad-hex")
+	f.Add("deadbeef")
+	f.Add("ffffffffffffffffffffffffffffffff")
+
+	f.Fuzz(func(_ *testing.T, rawHex string) {
+		// The function should not panic regardless of input
+		_, _ = TxFromHex(rawHex)
+	})
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -14,35 +14,35 @@ func TestTxFromHex(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name          string
 		inputHex      string
 		expectedTxID  string
 		expectedNil   bool
 		expectedError bool
 	}{
-		{"", "", true, true},
-		{"0", "", true, true},
-		{"000", "", true, true},
-		{"bad-hex", "", true, true},
-		{"01000000012adda020db81f2155ebba69e7c841275517ebf91674268c32ff2f5c7e2853b2c010000006b483045022100872051ef0b6c47714130c12a067db4f38b988bfc22fe270731c2146f5229386b02207abf68bbf092ec03e2c616defcc4c868ad1fc3cdbffb34bcedfab391a1274f3e412102affe8c91d0a61235a3d07b1903476a2e2f7a90451b2ed592fea9937696a07077ffffffff02ed1a0000000000001976a91491b3753cf827f139d2dc654ce36f05331138ddb588acc9670300000000001976a914da036233873cc6489ff65a0185e207d243b5154888ac00000000", "64cd12102af20195d54a107e0ee5989ac5db3491893a0b9d42e24354732a22a5", false, false},
+		{"empty hex errors", "", "", true, true},
+		{"single char errors", "0", "", true, true},
+		{"odd length errors", "000", "", true, true},
+		{"bad hex errors", "bad-hex", "", true, true},
+		{"valid raw tx", "01000000012adda020db81f2155ebba69e7c841275517ebf91674268c32ff2f5c7e2853b2c010000006b483045022100872051ef0b6c47714130c12a067db4f38b988bfc22fe270731c2146f5229386b02207abf68bbf092ec03e2c616defcc4c868ad1fc3cdbffb34bcedfab391a1274f3e412102affe8c91d0a61235a3d07b1903476a2e2f7a90451b2ed592fea9937696a07077ffffffff02ed1a0000000000001976a91491b3753cf827f139d2dc654ce36f05331138ddb588acc9670300000000001976a914da036233873cc6489ff65a0185e207d243b5154888ac00000000", "64cd12102af20195d54a107e0ee5989ac5db3491893a0b9d42e24354732a22a5", false, false},
 	}
 
 	for _, test := range tests {
-		rawTx, err := TxFromHex(test.inputHex)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error not expected but got: %s", t.Name(), test.inputHex, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] inputted and error was expected", t.Name(), test.inputHex)
-		}
-		if rawTx == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was nil but not expected", t.Name(), test.inputHex)
-		}
-		if rawTx != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%s] inputted and was NOT nil but expected to be nil", t.Name(), test.inputHex)
-		}
-		if rawTx != nil && rawTx.TxID() != test.expectedTxID {
-			t.Fatalf("%s Failed: [%s] inputted [%s] expected but failed comparison of txIDs, got: %s", t.Name(), test.inputHex, test.expectedTxID, rawTx.TxID())
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			rawTx, err := TxFromHex(test.inputHex)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.expectedNil {
+				assert.Nil(t, rawTx)
+			} else {
+				require.NotNil(t, rawTx)
+				assert.Equal(t, test.expectedTxID, rawTx.TxID())
+			}
+		})
 	}
 }
 
@@ -59,7 +59,7 @@ func ExampleTxFromHex() {
 
 // BenchmarkTxFromHex benchmarks the method TxFromHex()
 func BenchmarkTxFromHex(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = TxFromHex("01000000012adda020db81f2155ebba69e7c841275517ebf91674268c32ff2f5c7e2853b2c010000006b483045022100872051ef0b6c47714130c12a067db4f38b988bfc22fe270731c2146f5229386b02207abf68bbf092ec03e2c616defcc4c868ad1fc3cdbffb34bcedfab391a1274f3e412102affe8c91d0a61235a3d07b1903476a2e2f7a90451b2ed592fea9937696a07077ffffffff02ed1a0000000000001976a91491b3753cf827f139d2dc654ce36f05331138ddb588acc9670300000000001976a914da036233873cc6489ff65a0185e207d243b5154888ac00000000")
 	}
 }
@@ -69,30 +69,20 @@ func TestCreateTx(t *testing.T) {
 	t.Parallel()
 
 	t.Run("basic valid tx", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 500,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
-		privateKey, err := WifToPrivateKey(testWIF)
-		require.NoError(t, err)
+		privateKey := mustTestPrivKey(t)
 		assert.NotNil(t, privateKey)
 
-		var tx *bt.Tx
-		tx, err = CreateTx(
+		tx, err := CreateTx(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
+			newTestOpReturns(),
 			privateKey,
 		)
 		require.NoError(t, err)
@@ -120,12 +110,7 @@ func TestCreateTx(t *testing.T) {
 // ExampleCreateTx example using CreateTx()
 func ExampleCreateTx() {
 	// Use a new UTXO
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     1000,
-	}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{
@@ -134,8 +119,6 @@ func ExampleCreateTx() {
 	}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
 	// Private key (from wif)
 	privateKey, err := WifToPrivateKey(testWIF)
@@ -148,7 +131,7 @@ func ExampleCreateTx() {
 	rawTx, err := CreateTx(
 		[]*Utxo{utxo},
 		[]*PayToAddress{payTo},
-		[]OpReturnData{opReturn1, opReturn2},
+		newTestOpReturns(),
 		privateKey,
 	)
 	if err != nil {
@@ -163,23 +146,21 @@ func ExampleCreateTx() {
 // BenchmarkCreateTx benchmarks the method CreateTx()
 func BenchmarkCreateTx(b *testing.B) {
 	// Use a new UTXO
-	utxo := &Utxo{TxID: testTxID, Vout: 0, ScriptPubKey: testScriptPubKey, Satoshis: 1000}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{Address: testAddress, Satoshis: 500}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
 	// Private key (from wif)
 	privateKey, _ := WifToPrivateKey(testWIF)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreateTx(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
+			newTestOpReturns(),
 			privateKey,
 		)
 	}
@@ -189,7 +170,10 @@ func BenchmarkCreateTx(b *testing.B) {
 func TestCreateTxErrors(t *testing.T) {
 	t.Parallel()
 
+	singleOpReturn := []OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}}
+
 	tests := []struct {
+		name           string
 		inputUtxos     []*Utxo
 		inputAddresses []*PayToAddress
 		inputOpReturns []OpReturnData
@@ -199,72 +183,57 @@ func TestCreateTxErrors(t *testing.T) {
 		expectedError  bool
 	}{
 		{
-			[]*Utxo{{
-				TxID:         testTxID,
-				Vout:         0,
-				ScriptPubKey: testScriptPubKey,
-				Satoshis:     1000,
-			}},
+			"utxo with pay-to and op_return",
+			[]*Utxo{newTestUtxo(1000)},
 			[]*PayToAddress{{
 				Address:  testAddress,
 				Satoshis: 500,
 			}},
-			[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
+			singleOpReturn,
 			testWIF,
 			"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006b483045022100bd31b3d9fbe18468086c0470e99f096e370f0c6ff41b6bb71f1a1d5c1b068ce302204f0c83d792a40337909b8b1bcea192722161f48dc475c653b7c352baa38eea6c412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff02f4010000000000001976a9147a1980655efbfec416b2b0c663a7b3ac0b6a25d288ac00000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
 			false,
 			false,
 		},
 		{
-			[]*Utxo{{
-				TxID:         testTxID,
-				Vout:         0,
-				ScriptPubKey: testScriptPubKey,
-				Satoshis:     1000,
-			}},
+			"outputs exceed inputs",
+			[]*Utxo{newTestUtxo(1000)},
 			[]*PayToAddress{{
 				Address:  testAddress,
 				Satoshis: 1500,
 			}},
-			[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
+			singleOpReturn,
 			testWIF,
 			"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006b483045022100bd31b3d9fbe18468086c0470e99f096e370f0c6ff41b6bb71f1a1d5c1b068ce302204f0c83d792a40337909b8b1bcea192722161f48dc475c653b7c352baa38eea6c412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff02f4010000000000001976a9147a1980655efbfec416b2b0c663a7b3ac0b6a25d288ac00000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
 			true,
 			true,
 		},
 		{
+			"nil utxos",
 			nil,
 			[]*PayToAddress{{
 				Address:  testAddress,
 				Satoshis: 500,
 			}},
-			[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
+			singleOpReturn,
 			testWIF,
 			"010000000002f4010000000000001976a9147a1980655efbfec416b2b0c663a7b3ac0b6a25d288ac00000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
 			false,
 			false,
 		},
 		{
-			[]*Utxo{{
-				TxID:         testTxID,
-				Vout:         0,
-				ScriptPubKey: testScriptPubKey,
-				Satoshis:     1000,
-			}},
+			"nil addresses with op_return",
+			[]*Utxo{newTestUtxo(1000)},
 			nil,
-			[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
+			singleOpReturn,
 			testWIF,
 			"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006a47304402205ba1a246371bf8db3fb6dfa75e1edaa18b6b86dc1775dc3f2aa3c38f22803ccc022057850f794ebf78e542228d301420d4ec896c30a2bc009b7e55c66120f6c5a57a412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff0100000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
 			false,
 			false,
 		},
 		{
-			[]*Utxo{{
-				TxID:         testTxID,
-				Vout:         0,
-				ScriptPubKey: testScriptPubKey,
-				Satoshis:     1000,
-			}},
+			"nil addresses and op_returns",
+			[]*Utxo{newTestUtxo(1000)},
 			nil,
 			nil,
 			testWIF,
@@ -273,6 +242,7 @@ func TestCreateTxErrors(t *testing.T) {
 			false,
 		},
 		{
+			"invalid script pubkey",
 			[]*Utxo{{
 				TxID:         testTxID,
 				Vout:         0,
@@ -283,24 +253,20 @@ func TestCreateTxErrors(t *testing.T) {
 				Address:  testAddress,
 				Satoshis: 500,
 			}},
-			[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
+			singleOpReturn,
 			testWIF,
 			"",
 			true,
 			true,
 		},
 		{
-			[]*Utxo{{
-				TxID:         testTxID,
-				Vout:         0,
-				ScriptPubKey: testScriptPubKey,
-				Satoshis:     1000,
-			}},
+			"invalid pay-to address",
+			[]*Utxo{newTestUtxo(1000)},
 			[]*PayToAddress{{
 				Address:  "invalid-address",
 				Satoshis: 500,
 			}},
-			[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
+			singleOpReturn,
 			testWIF,
 			"",
 			true,
@@ -308,31 +274,31 @@ func TestCreateTxErrors(t *testing.T) {
 		},
 	}
 
-	var rawTx *bt.Tx
 	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-		// Private key (from wif)
-		privateKey, err := WifToPrivateKey(test.inputWif)
-		if err != nil && !test.expectedError {
-			t.Fatalf("error occurred: %s", err.Error())
-		}
+			// Private key (from wif)
+			privateKey, err := WifToPrivateKey(test.inputWif)
+			require.NoError(t, err)
 
-		rawTx, err = CreateTx(test.inputUtxos, test.inputAddresses, test.inputOpReturns, privateKey)
-		if err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%v] [%v] [%s] inputted and error not expected but got: %s", t.Name(), test.inputUtxos, test.inputAddresses, test.inputOpReturns, test.inputWif, err.Error())
-		}
-		if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%v] [%v] [%v] [%s] inputted and error was expected", t.Name(), test.inputUtxos, test.inputAddresses, test.inputOpReturns, test.inputWif)
-		}
-		if rawTx == nil && !test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%v] [%v] [%s] inputted and nil was not expected", t.Name(), test.inputUtxos, test.inputAddresses, test.inputOpReturns, test.inputWif)
-		}
-		if rawTx != nil && test.expectedNil {
-			t.Fatalf("%s Failed: [%v] [%v] [%v] [%s] inputted and nil was expected", t.Name(), test.inputUtxos, test.inputAddresses, test.inputOpReturns, test.inputWif)
-		}
-		if rawTx != nil && rawTx.String() != test.expectedRawTx {
-			t.Fatalf("%s Failed: [%v] [%v] [%v] [%s] inputted [%s] expected but failed comparison of scripts, got: %s", t.Name(), test.inputUtxos, test.inputAddresses, test.inputOpReturns, test.inputWif, test.expectedRawTx, rawTx.String())
-		}
+			rawTx, err := CreateTx(test.inputUtxos, test.inputAddresses, test.inputOpReturns, privateKey)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if test.expectedNil {
+				assert.Nil(t, rawTx)
+			} else {
+				require.NotNil(t, rawTx)
+			}
+
+			if rawTx != nil {
+				assert.Equal(t, test.expectedRawTx, rawTx.String())
+			}
+		})
 	}
 }
 
@@ -341,25 +307,17 @@ func TestCreateTxUsingWif(t *testing.T) {
 	t.Parallel()
 
 	t.Run("valid tx", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 500,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
 		tx, err := CreateTxUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
+			newTestOpReturns(),
 			testWIF,
 		)
 		require.NoError(t, err)
@@ -367,25 +325,17 @@ func TestCreateTxUsingWif(t *testing.T) {
 	})
 
 	t.Run("invalid wif", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 500,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
 		tx, err := CreateTxUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
+			newTestOpReturns(),
 			"",
 		)
 		require.Error(t, err)
@@ -396,12 +346,7 @@ func TestCreateTxUsingWif(t *testing.T) {
 // ExampleCreateTxUsingWif example using CreateTxUsingWif()
 func ExampleCreateTxUsingWif() {
 	// Use a new UTXO
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     1000,
-	}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{
@@ -410,14 +355,12 @@ func ExampleCreateTxUsingWif() {
 	}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
 	// Generate the TX
 	rawTx, err := CreateTxUsingWif(
 		[]*Utxo{utxo},
 		[]*PayToAddress{payTo},
-		[]OpReturnData{opReturn1, opReturn2},
+		newTestOpReturns(),
 		testWIF,
 	)
 	if err != nil {
@@ -432,20 +375,18 @@ func ExampleCreateTxUsingWif() {
 // BenchmarkCreateTxUsingWif benchmarks the method CreateTxUsingWif()
 func BenchmarkCreateTxUsingWif(b *testing.B) {
 	// Use a new UTXO
-	utxo := &Utxo{TxID: testTxID, Vout: 0, ScriptPubKey: testScriptPubKey, Satoshis: 1000}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{Address: testAddress, Satoshis: 500}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreateTxUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
+			newTestOpReturns(),
 			testWIF,
 		)
 	}
@@ -456,25 +397,17 @@ func TestCalculateFeeForTx(t *testing.T) {
 	t.Parallel()
 
 	t.Run("valid tx", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 868,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
 		rawTx, err := CreateTxUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
+			newTestOpReturns(),
 			testWIF,
 		)
 		require.NoError(t, err)
@@ -676,7 +609,7 @@ func BenchmarkCalculateFeeForTx(b *testing.B) {
 		b.Fatalf("error occurred: %s", err.Error())
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = CalculateFeeForTx(tx, nil, nil)
 	}
 }
@@ -686,31 +619,21 @@ func TestCreateTxWithChange(t *testing.T) {
 	t.Parallel()
 
 	t.Run("basic tx", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 500,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
-		privateKey, err := WifToPrivateKey(testWIF)
-		require.NoError(t, err)
+		privateKey := mustTestPrivKey(t)
 		assert.NotNil(t, privateKey)
 
-		var rawTx *bt.Tx
-		rawTx, err = CreateTxWithChange(
+		rawTx, err := CreateTxWithChange(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			newTestOpReturns(),
+			testChangeAddress,
 			nil,
 			nil,
 			privateKey,
@@ -754,7 +677,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				}},
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006b483045022100b95aff403574aba31b1786e5f5ddb3c57356a13e6207b66babb16a6d851d7cfe02200d0f570f619e4c05b5b7213ce673f46549f9a7ee95814f3ec0cc0233fd54c85e412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff03f4010000000000001976a9147a1980655efbfec416b2b0c663a7b3ac0b6a25d288ac71010000000000001976a914c9d8699bdea34b131e737447b50a8b1af0b040bf88ac00000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
@@ -770,7 +693,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				nil,
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006b48304502210092b9d4a913d7103e8770bdeb45528b6aed02126fafdfc64c728243714eac250002205fa4963a90fd69f6ae4cbf02c2ecc2367d585eb616244fb7c85adf4fef468a21412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff0277030000000000001976a914c9d8699bdea34b131e737447b50a8b1af0b040bf88ac00000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
@@ -786,7 +709,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				nil,
 				nil,
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006a4730440220029595a3bc3e94f92b1d08faf298ba938cb7c9824393789a1f3afc5ea5e172a802204d224492ab440c8180b45f39a25e270b0fb0d2fc74d8362db52e3ff960d9dc5d412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff0187030000000000001976a914c9d8699bdea34b131e737447b50a8b1af0b040bf88ac00000000",
@@ -805,7 +728,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				}},
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006b483045022100fdf1c12b1512db7ced357358a333f3abf0f7b2d0b1a62c8e727d07627d702d5502207446779354f63e785bb8a46c9b2fb9a6da8a6d5503ee90ff35bb4c0774d38e62412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff0276030000000000001976a9147a1980655efbfec416b2b0c663a7b3ac0b6a25d288ac00000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
@@ -856,7 +779,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				}},
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006b483045022100bd31b3d9fbe18468086c0470e99f096e370f0c6ff41b6bb71f1a1d5c1b068ce302204f0c83d792a40337909b8b1bcea192722161f48dc475c653b7c352baa38eea6c412102ea87d1fd77d169bd56a71e700628113d0f8dfe57faa0ba0e55a36f9ce8e10be3ffffffff02f4010000000000001976a9147a1980655efbfec416b2b0c663a7b3ac0b6a25d288ac00000000000000001a006a07707265666978310c6578616d706c65206461746102133700000000",
@@ -870,7 +793,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				}},
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"",
@@ -889,7 +812,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				}},
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"",
@@ -908,7 +831,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				}},
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"",
@@ -946,7 +869,7 @@ func TestCreateTxWithChange(t *testing.T) {
 				}},
 				[]OpReturnData{{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}},
 				testWIF,
-				"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+				testChangeAddress,
 				nil,
 				nil,
 				"",
@@ -974,12 +897,7 @@ func TestCreateTxWithChange(t *testing.T) {
 // ExampleCreateTxWithChange example using CreateTxWithChange()
 func ExampleCreateTxWithChange() {
 	// Use a new UTXO
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     1000,
-	}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{
@@ -988,8 +906,6 @@ func ExampleCreateTxWithChange() {
 	}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
 	// Get private key from wif
 	privateKey, err := WifToPrivateKey(testWIF)
@@ -1003,8 +919,8 @@ func ExampleCreateTxWithChange() {
 	rawTx, err = CreateTxWithChange(
 		[]*Utxo{utxo},
 		[]*PayToAddress{payTo},
-		[]OpReturnData{opReturn1, opReturn2},
-		"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+		newTestOpReturns(),
+		testChangeAddress,
 		nil,
 		nil,
 		privateKey,
@@ -1021,24 +937,22 @@ func ExampleCreateTxWithChange() {
 // BenchmarkCreateTxWithChange benchmarks the method CreateTxWithChange()
 func BenchmarkCreateTxWithChange(b *testing.B) {
 	// Use a new UTXO
-	utxo := &Utxo{TxID: testTxID, Vout: 0, ScriptPubKey: testScriptPubKey, Satoshis: 1000}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{Address: testAddress, Satoshis: 500}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
 	// Get private key from wif
 	privateKey, _ := WifToPrivateKey(testWIF)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreateTxWithChange(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			newTestOpReturns(),
+			testChangeAddress,
 			nil,
 			nil,
 			privateKey,
@@ -1053,26 +967,18 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	t.Parallel()
 
 	t.Run("valid tx", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 500,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
 		rawTx, err := CreateTxWithChangeUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			newTestOpReturns(),
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1092,9 +998,6 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("valid tx - multiple inputs - send all", func(t *testing.T) {
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
 		rawTx, err := CreateTxWithChangeUsingWif(
 			[]*Utxo{{
 				TxID:         "9e88ca8eec0845e9e864c024bc5e6711e670932c9c7d929f9fccdb2c440ae28e",
@@ -1111,7 +1014,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 				Address:  "1DE7mZ9g3zmzWLM729fneui7eypfX8BBfC",
 				Satoshis: 5689 + 5689,
 			}},
-			[]OpReturnData{opReturn1, opReturn2},
+			newTestOpReturns(),
 			"1BxGFoRPSFgYxoAStEncL6HuELqPkV3JVj",
 			nil,
 			nil,
@@ -1127,12 +1030,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send entire utxo amount", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
@@ -1143,7 +1041,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
 			nil,
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1162,12 +1060,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send entire utxo amount - multiple pay to addresses", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		rawTx, err := CreateTxWithChangeUsingWif(
 			[]*Utxo{utxo},
@@ -1190,7 +1083,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 				},
 			},
 			nil,
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1212,12 +1105,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send almost entire utxo amount - 5 sat diff", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
@@ -1228,7 +1116,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
 			nil,
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1250,12 +1138,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send almost entire utxo amount - 1 sat diff", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
@@ -1266,7 +1149,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
 			nil,
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1286,12 +1169,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send more than utxos provided - pay to", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
@@ -1302,7 +1180,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
 			nil,
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1312,26 +1190,18 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send entire utxo - with op return", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 1000,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
 		rawTx, err := CreateTxWithChangeUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			newTestOpReturns(),
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1344,12 +1214,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send entire utxo amount - last pay-to does not cover fee", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		rawTx, err := CreateTxWithChangeUsingWif(
 			[]*Utxo{utxo},
@@ -1364,7 +1229,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 				},
 			},
 			nil,
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1387,12 +1252,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send entire utxo - cannot cover fee in any pay-to", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		rawTx, err := CreateTxWithChangeUsingWif(
 			[]*Utxo{utxo},
@@ -1479,7 +1339,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 				},
 			},
 			nil,
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1489,12 +1349,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send entire utxo using data, leaving 1-2 sats", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
@@ -1510,7 +1365,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
 			[]OpReturnData{opReturn1},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1521,12 +1376,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("send entire utxo using data, too much data", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
@@ -1542,7 +1392,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
 			[]OpReturnData{opReturn1},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,
@@ -1552,26 +1402,18 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 	})
 
 	t.Run("invalid wif", func(t *testing.T) {
-		utxo := &Utxo{
-			TxID:         testTxID,
-			Vout:         0,
-			ScriptPubKey: testScriptPubKey,
-			Satoshis:     1000,
-		}
+		utxo := newTestUtxo(1000)
 
 		payTo := &PayToAddress{
 			Address:  testAddress,
 			Satoshis: 500,
 		}
 
-		opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-		opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
-
 		rawTx, err := CreateTxWithChangeUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			newTestOpReturns(),
+			testChangeAddress,
 			nil,
 			nil,
 			"",
@@ -1584,12 +1426,7 @@ func TestCreateTxWithChangeUsingWif(t *testing.T) {
 // ExampleCreateTxWithChangeUsingWif example using CreateTxWithChangeUsingWif()
 func ExampleCreateTxWithChangeUsingWif() {
 	// Use a new UTXO
-	utxo := &Utxo{
-		TxID:         testTxID,
-		Vout:         0,
-		ScriptPubKey: testScriptPubKey,
-		Satoshis:     1000,
-	}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{
@@ -1598,15 +1435,13 @@ func ExampleCreateTxWithChangeUsingWif() {
 	}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
 	// Generate the TX
 	rawTx, err := CreateTxWithChangeUsingWif(
 		[]*Utxo{utxo},
 		[]*PayToAddress{payTo},
-		[]OpReturnData{opReturn1, opReturn2},
-		"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+		newTestOpReturns(),
+		testChangeAddress,
 		nil,
 		nil,
 		testWIF,
@@ -1623,21 +1458,19 @@ func ExampleCreateTxWithChangeUsingWif() {
 // BenchmarkCreateTxWithChangeUsingWif benchmarks the method CreateTxWithChangeUsingWif()
 func BenchmarkCreateTxWithChangeUsingWif(b *testing.B) {
 	// Use a new UTXO
-	utxo := &Utxo{TxID: testTxID, Vout: 0, ScriptPubKey: testScriptPubKey, Satoshis: 1000}
+	utxo := newTestUtxo(1000)
 
 	// Add a pay-to address
 	payTo := &PayToAddress{Address: testAddress, Satoshis: 500}
 
 	// Add some op return data
-	opReturn1 := OpReturnData{[]byte("prefix1"), []byte("example data"), []byte{0x13, 0x37}}
-	opReturn2 := OpReturnData{[]byte("prefix2"), []byte("more example data")}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = CreateTxWithChangeUsingWif(
 			[]*Utxo{utxo},
 			[]*PayToAddress{payTo},
-			[]OpReturnData{opReturn1, opReturn2},
-			"1KQG5AY9GrPt3b5xrFqVh2C3YEhzSdu4kc",
+			newTestOpReturns(),
+			testChangeAddress,
 			nil,
 			nil,
 			testWIF,

--- a/verify_test.go
+++ b/verify_test.go
@@ -19,6 +19,7 @@ func TestVerifyMessage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name           string
 		inputAddress   string
 		inputSignature string
 		inputData      string
@@ -26,6 +27,7 @@ func TestVerifyMessage(t *testing.T) {
 		mainnet        bool
 	}{
 		{
+			"valid compressed message",
 			"12SsqqYk43kggMBpSvWHwJwR31NsgMePKS",
 			"HFxPx8JHsCiivB+DW/RgNpCLT6yG3j436cUNWKekV3ORBrHNChIjeVReyAco7PVmmDtVD3POs9FhDlm/nk5I6O8=",
 			"test message",
@@ -33,6 +35,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"valid long message",
 			"1LN5p7Eg9Zju1b4g4eFPTBMPoMZGCxzrET",
 			"IKmgOFrfWRffRNjrQcJQHSBD7WL2di+4doWdaz/a/p5RUiT7ErpUqbYeLi0yzmONFaV8uLWF2vydTjA8W8KnjZU=",
 			"This time I'm writing a new message that is obnoxiously long af. This time I'm writing a " +
@@ -49,6 +52,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"valid testnet address",
 			"mrH55sFASmaDJZ46RnKjMi11nA99b4d8GH",
 			"IL3hIysOVTZu9NJp5YWkPh7PSrnX+kFuFArVB+ETNObqUeYtboWjfV2H7CVmOJGJkjo4REHJx26zCGrH71ySNRo=",
 			"Testing!",
@@ -56,6 +60,7 @@ func TestVerifyMessage(t *testing.T) {
 			false,
 		},
 		{
+			"testnet address with mainnet flag errors",
 			"mrH55sFASmaDJZ46RnKjMi11nA99b4d8GH",
 			"IL3hIysOVTZu9NJp5YWkPh7PSrnX+kFuFArVB+ETNObqUeYtboWjfV2H7CVmOJGJkjo4REHJx26zCGrH71ySNRo=",
 			"Testing!",
@@ -63,6 +68,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"mismatched address errors",
 			"1LN5p7Eg9Zju1b4g4eFPTBMPoMZGCxzrET",
 			"IBDscOd/Ov4yrd/YXantqajSAnW4fudpfr2KQy5GNo9pZybF12uNaal4KI822UpQLS/UJD+UK2SnNMn6Z3E4na8=",
 			"Testing!",
@@ -70,6 +76,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"empty signature errors",
 			"1FiyJnrgwBc3Ff83V1yRWAkmXBdGrDQnXQ",
 			"",
 			"Testing!",
@@ -77,6 +84,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"empty data errors",
 			"1FiyJnrgwBc3Ff83V1yRWAkmXBdGrDQnXQ",
 			"IBDscOd/Ov4yrd/YXantqajSAnW4fudpfr2KQy5GNo9pZybF12uNaal4KI822UpQLS/UJD+UK2SnNMn6Z3E4na8=",
 			"",
@@ -84,6 +92,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"invalid address 0 errors",
 			"0",
 			"IBDscOd/Ov4yrd/YXantqajSAnW4fudpfr2KQy5GNo9pZybF12uNaal4KI822UpQLS/UJD+UK2SnNMn6Z3E4na8=",
 			"Testing!",
@@ -91,6 +100,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"tampered signature errors",
 			"1FiyJnrgwBc3Ff83V1yRWAkmXBdGrDQnXQ",
 			"GBDscOd/Ov4yrd/YXantqajSAnW4fudpfr2KQy5GNo9pZybF12uNaal4KI822UpQLS/UJD+UK2SnNMn6Z3E4naZ=",
 			"Testing!",
@@ -98,6 +108,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"short signature errors",
 			"1FiyJnrgwBc3Ff83V1yRWAkmXBdGrDQnXQ",
 			"GBD=",
 			"Testing!",
@@ -105,6 +116,7 @@ func TestVerifyMessage(t *testing.T) {
 			true,
 		},
 		{
+			"malformed base64 signature errors",
 			"1FiyJnrgwBc3Ff83V1yRWAkmXBdGrDQnXQ",
 			"GBse5w0f839t8wej8f2D=",
 			"Testing!",
@@ -114,11 +126,15 @@ func TestVerifyMessage(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if err := VerifyMessage(test.inputAddress, test.inputSignature, test.inputData, test.mainnet); err != nil && !test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] [%s] inputted and error not expected but got: %s", t.Name(), test.inputAddress, test.inputSignature, test.inputData, err.Error())
-		} else if err == nil && test.expectedError {
-			t.Fatalf("%s Failed: [%s] [%s] [%s] inputted and error was expected", t.Name(), test.inputAddress, test.inputSignature, test.inputData)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := VerifyMessage(test.inputAddress, test.inputSignature, test.inputData, test.mainnet)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -139,7 +155,7 @@ func ExampleVerifyMessage() {
 
 // BenchmarkVerifyMessage benchmarks the method VerifyMessage()
 func BenchmarkVerifyMessage(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = VerifyMessage(
 			"1FiyJnrgwBc3Ff83V1yRWAkmXBdGrDQnXQ",
 			"IBDscOd/Ov4yrd/YXantqajSAnW4fudpfr2KQy5GNo9pZybF12uNaal4KI822UpQLS/UJD+UK2SnNMn6Z3E4na8=",
@@ -219,7 +235,7 @@ func ExampleVerifyMessageDER() {
 func BenchmarkVerifyMessageDER(b *testing.B) {
 	message := []byte(`{"apiVersion":"0.1.0","timestamp":"2020-10-08T14:25:31.539Z","expiryTime":"2020-10-08T14:35:31.539Z","minerId":"` + testDERPubKey + `","currentHighestBlockHash":"0000000000000000021af4ee1f179a64e530bf818ef67acd09cae24a89124519","currentHighestBlockHeight":656007,"minerReputation":null,"fees":[{"id":1,"feeType":"standard","miningFee":{"satoshis":500,"bytes":1000},"relayFee":{"satoshis":250,"bytes":1000}},{"id":2,"feeType":"data","miningFee":{"satoshis":500,"bytes":1000},"relayFee":{"satoshis":250,"bytes":1000}}]}`)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = VerifyMessageDER(sha256.Sum256(message), testDERPubKey, testDERSignature)
 	}
 }

--- a/wif.go
+++ b/wif.go
@@ -170,7 +170,7 @@ func (w *WIF) SerializePubKey() []byte {
 // the length of the source is smaller than the passed size, leading zero bytes
 // are appended to dst before appending src.
 func paddedAppend(size uint, dst, src []byte) []byte {
-	for i := 0; i < int(size)-len(src); i++ {
+	for range int(size) - len(src) {
 		dst = append(dst, 0)
 	}
 	return append(dst, src...)

--- a/wif_fuzz_test.go
+++ b/wif_fuzz_test.go
@@ -1,0 +1,24 @@
+package bitcoin
+
+import (
+	"testing"
+)
+
+// FuzzDecodeWIF tests DecodeWIF with various strings to ensure it never panics
+// regardless of input.
+func FuzzDecodeWIF(f *testing.F) {
+	// Seed corpus with valid (compressed/uncompressed) and invalid WIFs
+	f.Add(testWIF)
+	f.Add(testUncompressedWIF)
+	f.Add(testCompressedWIF)
+	f.Add("")
+	f.Add("0")
+	f.Add("invalid")
+	f.Add("5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1E") // truncated
+	f.Add("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+
+	f.Fuzz(func(_ *testing.T, wif string) {
+		// The function should not panic regardless of input
+		_, _ = DecodeWIF(wif)
+	})
+}

--- a/wif_test.go
+++ b/wif_test.go
@@ -11,13 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testPrivateKeyHex (defined in test_constants_test.go) encodes to these
-// mainnet WIFs (uncompressed leads with '5', compressed with 'K'/'L').
-const (
-	testUncompressedWIF = "5JTHas7yTFMBLqgFogxZFf8Vc5uKEbkE7yQAQ2g3xPHo2sNG1Ei"
-	testCompressedWIF   = "Kz32CUDnArL4eZrGM5NDMhJ5FrduV2MnumwEUePN3TP8AwSRRFvQ"
-)
-
 // TestNewWIFUncompressed verifies uncompressed WIF output is preserved (51 chars,
 // leading '5') and round-trips back to the original private key.
 func TestNewWIFUncompressed(t *testing.T) {


### PR DESCRIPTION
## What Changed

A Go 1.25 modernization and deduplication pass. The public API, wire formats, and behavior are unchanged.

**Production internals (behavior-preserving):**
- Extracted shared logic into unexported helpers: `privateKeyFromHex` (3 call sites), ECIES `deriveKeys`, collapsed the identical HD-key string wrappers, and looped `GetPublicKeysForPath`'s twin blocks.
- Reused `hash.Sha256d` for the address double-SHA256 (removed the hand-rolled `crypto/sha256` version).
- Adopted modern idioms: `slices.Backward`, `for range n`, `for b.Loop()` in benchmarks, and `s == ""` for string emptiness.
- Tidied `transaction.go`: merged redundant fee guards and hoisted OP_RETURN prefix constants.

**Tests:**
- Converted the legacy anonymous-table + `if/else`/`t.Fatalf` tests to `t.Run` named subtests with `t.Parallel()` and testify `require`/`assert`.
- Centralized duplicated constants into `test_constants_test.go` and added reusable fixtures/helpers (`newTestUtxo`, `newTestOpReturns`, `mustTestPrivKey`, `mustHDKey`).
- Added coverage for `DefaultStandardFee`, `GenerateSharedKeyPair`, and the `A25` accessors, plus fuzz targets for `TxFromHex` and `DecodeWIF`.

**Docs:** README feature list now documents a few previously-omitted public functions (Address from PubKey, Validate a Base58 Address, PubKey from Signature, Create Tx with Change using WIF).

## Why It Was Necessary

The library is already on Go 1.25 but carried pre-1.22 idioms, hand-rolled implementations that duplicated stdlib/SDK functionality, and two eras of test style. This pass removes duplication (a maintenance hazard), aligns the code with modern Go, and makes the test suite uniform, parallel, and better-covered — without touching the widely-imported public API.

## Testing Performed

- `magex test` and `magex test:race` — pass
- `magex lint` (golangci-lint, 62 linters + `go vet`) — 0 issues
- `staticcheck ./...`, `gofumpt -l .` — clean
- `go-pre-commit run --all-files` — pass (gitleaks, fumpt, eof, mod-tidy, whitespace)
- Wire-format known-answer vectors (ECIES/WIF) and all address/sign/verify vectors remain green
- Fuzz targets smoke-tested; example programs still build and run

## Impact / Risk

**Low.** No exported signature, name, or behavior changes — a drop-in for all downstream consumers. Error strings are unchanged (error wrapping intentionally not introduced). Crypto-internal refactors are guarded by the existing byte-for-byte compatibility vectors. Net diff is roughly flat despite meaningful dedup, driven by the test-suite conversion.

## Notifications
- @mrz1836
